### PR TITLE
Update integration tests - tenantId according to the properties

### DIFF
--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/BasicConfigurationForTests.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/BasicConfigurationForTests.java
@@ -5,12 +5,14 @@ import com.evolveum.polygon.connector.msgraphapi.MSGraphConfiguration;
 public class BasicConfigurationForTests {
 
     private PropertiesParser parser = new PropertiesParser();
+    protected String tenantId;
 
     protected MSGraphConfiguration getConfiguration() {
         MSGraphConfiguration msGraphConfiguration = new MSGraphConfiguration();
         msGraphConfiguration.setClientSecret(parser.getClientSecret());
         msGraphConfiguration.setClientId(parser.getClientId());
         msGraphConfiguration.setTenantId(parser.getTenantId());
+        this.tenantId = parser.getTenantId();
         return msGraphConfiguration;
     }
 

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/CreateActionTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/CreateActionTest.java
@@ -67,8 +67,9 @@ public class CreateActionTest extends BasicConfigurationForTests {
         attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount.add(AttributeBuilder.build("displayName", "testing"));
+        attributesAccount.add(AttributeBuilder.build("mail", "testing@example.com"));
         attributesAccount.add(AttributeBuilder.build("mailNickname", "testing"));
-        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "testing@TENANTID"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "testing@" + tenantId));
         ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
 
         try {
@@ -92,8 +93,9 @@ public class CreateActionTest extends BasicConfigurationForTests {
         attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount.add(AttributeBuilder.build("displayName", "testing"));
+        attributesAccount.add(AttributeBuilder.build("mail", "testing@example.com"));
         attributesAccount.add(AttributeBuilder.build("mailNickname", "testing"));
-        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "testing@TENANTID"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "testing@" + tenantId));
         GuardedString pass = new GuardedString("Password99".toCharArray());
         attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
         ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
@@ -142,8 +144,9 @@ public class CreateActionTest extends BasicConfigurationForTests {
         attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount.add(AttributeBuilder.build("displayName", "testing"));
+        attributesAccount.add(AttributeBuilder.build("mail", "testing@example.com"));
         attributesAccount.add(AttributeBuilder.build("mailNickname", "testing"));
-        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "testing@TENANTID"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "testing@" + tenantId));
         GuardedString pass = new GuardedString("passw".toCharArray());
         attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
         ObjectClass objectClassAccount = ObjectClass.ACCOUNT;

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/DeleteActionTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/DeleteActionTest.java
@@ -33,8 +33,9 @@ public class DeleteActionTest extends BasicConfigurationForTests {
         attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount.add(AttributeBuilder.build("displayName", "testing"));
+        attributesAccount.add(AttributeBuilder.build("mail", "testing@example.com"));
         attributesAccount.add(AttributeBuilder.build("mailNickname", "testing"));
-        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "testing@TENANTID"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "testing@" + tenantId));
         GuardedString pass = new GuardedString("Password99".toCharArray());
         attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
         ObjectClass objectClassAccount = ObjectClass.ACCOUNT;

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/FilteringTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/FilteringTest.java
@@ -37,8 +37,9 @@ public class FilteringTest extends BasicConfigurationForTests {
         attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount.add(AttributeBuilder.build("displayName", "Pink"));
+        attributesAccount.add(AttributeBuilder.build("mail", "Pink@example.com"));
         attributesAccount.add(AttributeBuilder.build("mailNickname", "Pink"));
-        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Pink@TENANTID"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Pink@" + tenantId));
         GuardedString pass = new GuardedString("HelloPassword99".toCharArray());
         attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
 
@@ -48,8 +49,9 @@ public class FilteringTest extends BasicConfigurationForTests {
         attributesAccount1.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount1.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount1.add(AttributeBuilder.build("displayName", "PinkAndGreen"));
+        attributesAccount1.add(AttributeBuilder.build("mail", "PinkAndGreen@example.com"));
         attributesAccount1.add(AttributeBuilder.build("mailNickname", "PinkAndGreen"));
-        attributesAccount1.add(AttributeBuilder.build("userPrincipalName", "PinkAndGreen@TENANTID"));
+        attributesAccount1.add(AttributeBuilder.build("userPrincipalName", "PinkAndGreen@" + tenantId));
         GuardedString pass1 = new GuardedString("HelloPassword99".toCharArray());
         attributesAccount1.add(AttributeBuilder.build("__PASSWORD__", pass1));
 
@@ -90,7 +92,7 @@ public class FilteringTest extends BasicConfigurationForTests {
 
 
         AttributeFilter equalsFilterAccount1;
-        equalsFilterAccount1 = (EqualsFilter) FilterBuilder.equalTo(AttributeBuilder.build("userPrincipalName", "Pink@TENANTID"));
+        equalsFilterAccount1 = (EqualsFilter) FilterBuilder.equalTo(AttributeBuilder.build("userPrincipalName", "Pink@" + tenantId));
         resultsAccount.clear();
         msGraphConnector.executeQuery(objectClassAccount, equalsFilterAccount1, handlerAccount, options);
         try {

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/GroupPerformanceTests.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/GroupPerformanceTests.java
@@ -88,8 +88,9 @@ public class GroupPerformanceTests extends BasicConfigurationForTests {
         attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount.add(AttributeBuilder.build("displayName", "Yellow"));
+        attributesAccount.add(AttributeBuilder.build("mail", "Yellow@example.com"));
         attributesAccount.add(AttributeBuilder.build("mailNickname", "Yellow"));
-        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Yellow@TENANTID"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Yellow@" + tenantId));
         GuardedString pass = new GuardedString("HelloPassword99".toCharArray());
         attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
 
@@ -125,8 +126,9 @@ public class GroupPerformanceTests extends BasicConfigurationForTests {
         attributesAccount3.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount3.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount3.add(AttributeBuilder.build("displayName", "Blue"));
+        attributesAccount3.add(AttributeBuilder.build("mail", "Blue@example.com"));
         attributesAccount3.add(AttributeBuilder.build("mailNickname", "Blue"));
-        attributesAccount3.add(AttributeBuilder.build("userPrincipalName", "Blue@TENANTID"));
+        attributesAccount3.add(AttributeBuilder.build("userPrincipalName", "Blue@" + tenantId));
         GuardedString pass3 = new GuardedString("HelloPassword99".toCharArray());
         attributesAccount3.add(AttributeBuilder.build("__PASSWORD__", pass3));
 
@@ -134,8 +136,9 @@ public class GroupPerformanceTests extends BasicConfigurationForTests {
         attributesAccount1.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount1.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount1.add(AttributeBuilder.build("displayName", "Red"));
+        attributesAccount1.add(AttributeBuilder.build("mail", "Red@example.com"));
         attributesAccount1.add(AttributeBuilder.build("mailNickname", "Red"));
-        attributesAccount1.add(AttributeBuilder.build("userPrincipalName", "Red@TENANTID"));
+        attributesAccount1.add(AttributeBuilder.build("userPrincipalName", "Red@" + tenantId));
         GuardedString pass1 = new GuardedString("HelloPassword99".toCharArray());
         attributesAccount1.add(AttributeBuilder.build("__PASSWORD__", pass1));
 
@@ -143,8 +146,9 @@ public class GroupPerformanceTests extends BasicConfigurationForTests {
         attributesAccount2.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount2.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount2.add(AttributeBuilder.build("displayName", "Black"));
+        attributesAccount2.add(AttributeBuilder.build("mail", "Black@example.com"));
         attributesAccount2.add(AttributeBuilder.build("mailNickname", "Black"));
-        attributesAccount2.add(AttributeBuilder.build("userPrincipalName", "Black@TENANTID"));
+        attributesAccount2.add(AttributeBuilder.build("userPrincipalName", "Black@" + tenantId));
         GuardedString pass2 = new GuardedString("HelloPassword99".toCharArray());
         attributesAccount2.add(AttributeBuilder.build("__PASSWORD__", pass2));
 

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/UpdateTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/UpdateTest.java
@@ -68,8 +68,9 @@ public class UpdateTest extends BasicConfigurationForTests {
         attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
         attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
         attributesAccount.add(AttributeBuilder.build("displayName", "testing1"));
+        attributesAccount.add(AttributeBuilder.build("mail", "testing1@example.com"));
         attributesAccount.add(AttributeBuilder.build("mailNickname", "testing1"));
-        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "tes1tin1g991@TENANTID"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "tes1tin1g991@" + tenantId));
         GuardedString pass = new GuardedString("Password99".toCharArray());
         attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
         ObjectClass objectClassAccount = ObjectClass.ACCOUNT;

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/UserPerformanceTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/UserPerformanceTest.java
@@ -44,8 +44,9 @@ public class UserPerformanceTest extends BasicConfigurationForTests {
             attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
             attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
             attributesAccount.add(AttributeBuilder.build("displayName", "Yellow" + i));
+            attributesAccount.add(AttributeBuilder.build("mail", "Yellow" + i + "@example.com"));
             attributesAccount.add(AttributeBuilder.build("mailNickname", "Yellow" + i));
-            attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Yellow" + i + "@TENANTID"));
+            attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Yellow" + i + "@" + tenantId));
             GuardedString pass = new GuardedString("HelloPassword99".toCharArray());
             attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
             msGraphConnector.init(conf);


### PR DESCRIPTION
This change updates the integration tests:
- real tenantId is used - which is already available in the custom properties because of the authentication
- added "mail" attribute for the account

Just a slight improvement. Complete fix would need some changes in connector itself too.