### PR TITLE
Support for licenses and their assignment

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
@@ -501,13 +501,13 @@ public class GroupProcessing extends ObjectProcessing {
     }
 
     @Override
-    protected void handleJSONObject(JSONObject group, ResultsHandler handler) {
+    protected boolean handleJSONObject(JSONObject group, ResultsHandler handler) {
         LOG.info("processingObjectFromGET (Object)");
         final ConnectorObject connectorObject = convertGroupJSONObjectToConnectorObject(
                 saturateGroupMembership(group)
         ).build();
         LOG.info("processingGroupObjectFromGET, group: {0}, \n\tconnectorObject: {1}", group.get("id"), connectorObject.toString());
-        handler.handle(connectorObject);
+        return handler.handle(connectorObject);
     }
 
     private ConnectorObjectBuilder convertGroupJSONObjectToConnectorObject(JSONObject group) {

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -1,0 +1,175 @@
+package com.evolveum.polygon.connector.msgraphapi;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.identityconnectors.framework.common.objects.Attribute;
+import org.identityconnectors.framework.common.objects.AttributeInfo;
+import org.identityconnectors.framework.common.objects.AttributeInfoBuilder;
+import org.identityconnectors.framework.common.objects.AttributeUtil;
+import org.identityconnectors.framework.common.objects.ConnectorObjectBuilder;
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.ObjectClassInfo;
+import org.identityconnectors.framework.common.objects.ObjectClassInfoBuilder;
+import org.identityconnectors.framework.common.objects.OperationOptions;
+import org.identityconnectors.framework.common.objects.ResultsHandler;
+import org.identityconnectors.framework.common.objects.SchemaBuilder;
+import org.identityconnectors.framework.common.objects.Uid;
+import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
+import org.identityconnectors.framework.common.objects.filter.Filter;
+import org.json.JSONObject;
+
+
+public class LicenseProcessing extends ObjectProcessing {
+    public static final String OBJECT_CLASS_NAME = "license";
+    public static final ObjectClass OBJECT_CLASS = new ObjectClass(OBJECT_CLASS_NAME);
+
+    private static String GRAPH_SUBSCRIBEDSKUS = "/subscribedSkus";
+
+    public static final String ATTR_ID = "id";
+    public static final String ATTR_APPLIESTO = "appliesTo";
+    public static final String ATTR_SKUID = "skuId";
+    public static final String ATTR_SKUPAATNUMBER = "skuPartNumber";
+    public static final String ATTR_CAPABILITYSTATUS = "capabilityStatus";
+    public static final String ATTR_CONSUMEDUNITS = "consumedUnits";
+    // prepaid units
+    public static final String ATTR_PREPAIDUNITS = "prepaidUnits";
+    public static final String ATTR_ENABLED = "enabled";
+    public static final String ATTR_SUSPENDED = "suspended";
+    public static final String ATTR_WARNING = "warning";
+    public static final String ATTR_PREPAIDUNITS__ENABLED = ATTR_PREPAIDUNITS + "." + ATTR_ENABLED;
+    // service plans
+    public static final String ATTR_SERVICEPLANS = "servicePlans";
+    public static final String ATTR_SERVICEPLANID = "servicePlanId";
+    public static final String ATTR_SERVICEPLANS__SERVICEPLANID = ATTR_SERVICEPLANS + "." + ATTR_SERVICEPLANID;
+
+    private static final String SELECTOR_FULL = selector(
+            ATTR_ID,
+            ATTR_APPLIESTO,
+            ATTR_SKUID,
+            ATTR_SKUPAATNUMBER,
+            ATTR_CAPABILITYSTATUS,
+            ATTR_CONSUMEDUNITS,
+            ATTR_PREPAIDUNITS,
+            ATTR_SERVICEPLANS
+    );
+    private static final String SELECTOR_PARTIAL = selector(
+            ATTR_ID,
+            ATTR_APPLIESTO,
+            ATTR_SKUID,
+            ATTR_SKUPAATNUMBER,
+            ATTR_CAPABILITYSTATUS,
+            ATTR_CONSUMEDUNITS
+    );
+
+    public LicenseProcessing(MSGraphConfiguration configuration) {
+        super(configuration, ICFPostMapper.builder().build());
+    }
+
+    public void buildLicenseObjectClass(SchemaBuilder schemaBuilder) {
+        schemaBuilder.defineObjectClass(objectClassInfo());
+    }
+
+    @Override
+    protected ObjectClassInfo objectClassInfo() {
+        Set<AttributeInfo> attributes = new HashSet<>();
+
+        attributes.add(new AttributeInfoBuilder(ATTR_ID)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_APPLIESTO)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_CAPABILITYSTATUS)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_CONSUMEDUNITS)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .setType(Integer.class)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_SKUID)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_SKUPAATNUMBER)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_PREPAIDUNITS__ENABLED)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .setMultiValued(true)
+                .build());
+        attributes.add(new AttributeInfoBuilder(ATTR_SERVICEPLANS__SERVICEPLANID)
+                .setCreateable(false)
+                .setUpdateable(false)
+                .setMultiValued(true)
+                .build());
+        return new ObjectClassInfoBuilder()
+                .setType(OBJECT_CLASS_NAME)
+                .addAllAttributeInfo(attributes)
+                .build();
+    }
+
+    private void get(ResultsHandler handler, String skuId, OperationOptions options) {
+        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS + "/" + skuId, SELECTOR_FULL, options, false);
+        LOG.info("JSONObject license {0}", json.toString());
+        handleJSONObject(json, handler);
+    }
+
+    private void list(ResultsHandler handler, OperationOptions options) {
+        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        String selector = SELECTOR_FULL;
+        if (options != null && options.getAllowPartialAttributeValues() != null && options.getAllowPartialAttributeValues())
+            selector = SELECTOR_PARTIAL;
+        JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS, selector, options, false);
+        LOG.info("JSONObject license {0}", json.toString());
+        handleJSONArray(json, handler);
+    }
+
+    public void executeQueryForLicense(Filter query, ResultsHandler handler, OperationOptions options) {
+        LOG.info("executeQueryForLicense()");
+
+        if (query instanceof EqualsFilter) {
+            final EqualsFilter equalsFilter = (EqualsFilter) query;
+            final Attribute attr = equalsFilter.getAttribute();
+            final String attrName = attr.getName();
+            LOG.info("query instanceof EqualsFilter");
+            if (attrName.equals(Uid.NAME) || attrName.equals(ATTR_ID)) {
+                String value = AttributeUtil.getAsStringValue(attr);
+                if (value == null)
+                    invalidAttributeValue("Uid", query);
+                get(handler, value, options);
+                return;
+            }
+        }
+
+        list(handler, options);
+    }
+
+    @Override
+    protected boolean handleJSONObject(JSONObject json, ResultsHandler handler) {
+        ConnectorObjectBuilder builder = new ConnectorObjectBuilder();
+        builder.setObjectClass(OBJECT_CLASS);
+
+        getUIDIfExists(json, ATTR_ID, builder);
+        getNAMEIfExists(json, ATTR_SKUPAATNUMBER, builder);
+
+        getIfExists(json, ATTR_ID, String.class, builder);
+        getIfExists(json, ATTR_APPLIESTO, String.class, builder);
+        getIfExists(json, ATTR_CAPABILITYSTATUS, String.class, builder);
+        getIfExists(json, ATTR_CONSUMEDUNITS, Integer.class, builder);
+        getIfExists(json, ATTR_SKUID, String.class, builder);
+        getIfExists(json, ATTR_SKUPAATNUMBER, String.class, builder);
+        getFromItemIfExists(json, ATTR_PREPAIDUNITS, ATTR_ENABLED, Integer.class, builder);
+        getFromArrayIfExists(json, ATTR_SERVICEPLANS, ATTR_SERVICEPLANID, String.class, builder);
+
+        return handler.handle(builder.build());
+    }
+
+}

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConfiguration.java
@@ -21,6 +21,7 @@ public class MSGraphConfiguration extends AbstractConfiguration
     private String tenantId = null;
     private String proxyHost;
     private String proxyPort;
+    private String[] disabledPlans = {};
 
     // invites
     private boolean inviteGuests;
@@ -86,6 +87,15 @@ public class MSGraphConfiguration extends AbstractConfiguration
         this.proxyPort = proxyPort;
     }
 
+    @ConfigurationProperty(order = 55, displayMessageKey = "DisabledPlans", helpMessageKey = "List of the SkuId:ServicePlanId,[ServicePlanId2...]. These service plan will be disabled during assignment of the each license. Friendly names are not supported. Default: (empty)")
+
+    public String[] getDisabledPlans() {
+        return disabledPlans;
+    }
+
+    public void setDisabledPlans(String[] disabledPlans) {
+        this.disabledPlans = disabledPlans;
+    }
 
     @ConfigurationProperty(order = 60, displayMessageKey = "InviteGuests", helpMessageKey = "Whether to allow creation of guest accounts by inviting users from outside the tenant (based on e-mail address only)")
 
@@ -157,6 +167,9 @@ public class MSGraphConfiguration extends AbstractConfiguration
             }
             if (proxyPortNo <= 0) throw new ConfigurationException("Proxy port value must be positive");
         }
+
+        if (disabledPlans == null)
+            throw new ConfigurationException("Disabled plans array can't be null");
 
         if (inviteGuests) {
             if (StringUtil.isBlank(inviteRedirectUrl))

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
@@ -121,9 +121,11 @@ public class MSGraphConnector implements Connector,
             SchemaBuilder schemaBuilder = new SchemaBuilder(MSGraphConnector.class);
             UserProcessing userProcessing = new UserProcessing(configuration, this);
             GroupProcessing groupProcessing = new GroupProcessing(configuration);
+            LicenseProcessing licenseProcessing = new LicenseProcessing(configuration);
 
             userProcessing.buildUserObjectClass(schemaBuilder);
             groupProcessing.buildGroupObjectClass(schemaBuilder);
+            licenseProcessing.buildLicenseObjectClass(schemaBuilder);
 
             return schemaBuilder.build();
         }
@@ -167,6 +169,9 @@ public class MSGraphConnector implements Connector,
         } else if (objectClass.is(ObjectClass.GROUP_NAME)) {
             GroupProcessing groupProcessing = new GroupProcessing(configuration);
             groupProcessing.executeQueryForGroup(query, handler, options);
+        } else if (objectClass.is(LicenseProcessing.OBJECT_CLASS_NAME)) {
+            LicenseProcessing licenseProcessing = new LicenseProcessing(configuration);
+            licenseProcessing.executeQueryForLicense(query, handler, options);
         } else {
             LOG.error("Attribute of type ObjectClass is not supported.");
             throw new UnsupportedOperationException("Attribute of type ObjectClass is not supported.");

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
@@ -92,6 +92,37 @@ abstract class ObjectProcessing {
         }
     }
 
+    private Object getValueFromItem(JSONObject object, String attrName, Class<?> type) {
+        if (object.has(attrName) && object.get(attrName) != null && !JSONObject.NULL.equals(object.get(attrName)) && !String.valueOf(object.get(attrName)).isEmpty()) {
+            if (type.equals(String.class))
+                return String.valueOf(object.get(attrName));
+            else
+                return object.get(attrName);
+        } else {
+            return null;
+        }
+    }
+
+    protected void getFromArrayIfExists(JSONObject object, String attrName, String subAttrName, Class<?> type, ConnectorObjectBuilder builder) {
+        if (object.has(attrName)) {
+            Object valueObject = object.get(attrName);
+            if (valueObject != null && !JSONObject.NULL.equals(valueObject)) {
+                if (valueObject instanceof JSONArray) {
+                    JSONArray objectArray = (JSONArray)valueObject;
+                    List<Object> values = new ArrayList<>();
+                    objectArray.forEach(it -> {
+                        if (it instanceof JSONObject) {
+                            Object subValue = getValueFromItem((JSONObject)it, subAttrName, type);
+                            if (subValue != null)
+                                values.add(subValue);
+                        }
+                    });
+                    builder.addAttribute(attrName + "." + subAttrName, values.toArray());
+                }
+            }
+        }
+    }
+
     protected <T> T addAttr(ConnectorObjectBuilder builder, String attrName, T attrVal) {
         if (attrVal != null) {
             if (attrVal instanceof String) {

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
@@ -103,6 +103,16 @@ abstract class ObjectProcessing {
         }
     }
 
+    protected void getFromItemIfExists(JSONObject object, String attrName, String subAttrName, Class<?> type, ConnectorObjectBuilder builder) {
+        if (object.has(attrName)) {
+            Object valueObject = object.get(attrName);
+            if (valueObject != null) {
+                Object subValue = getValueFromItem((JSONObject)valueObject, subAttrName, type);
+                builder.addAttribute(attrName + "." + subAttrName, subValue);
+            }
+        }
+    }
+
     protected void getFromArrayIfExists(JSONObject object, String attrName, String subAttrName, Class<?> type, ConnectorObjectBuilder builder) {
         if (object.has(attrName)) {
             Object valueObject = object.get(attrName);

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
@@ -345,9 +345,9 @@ abstract class ObjectProcessing {
         return false;
     }
 
-    protected abstract void handleJSONObject(JSONObject object, ResultsHandler handler);
+    protected abstract boolean handleJSONObject(JSONObject object, ResultsHandler handler);
 
-    protected void handleJSONArray(JSONObject users, ResultsHandler handler) {
+    protected boolean handleJSONArray(JSONObject users, ResultsHandler handler) {
         String jsonStr = users.toString();
         JSONObject jsonObj = new JSONObject(jsonStr);
 
@@ -356,15 +356,17 @@ abstract class ObjectProcessing {
             value = jsonObj.getJSONArray("value");
         } catch (JSONException e) {
             LOG.info("No objects in JSON Array");
-            return;
+            return false;
         }
         int length = value.length();
         LOG.info("jsonObj length: {0}", length);
 
         for (int i = 0; i < length; i++) {
             JSONObject user = value.getJSONObject(i);
-            handleJSONObject(user, handler);
+            if (!handleJSONObject(user, handler))
+                return false;
         }
+        return true;
     }
 
     /**

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -700,13 +700,13 @@ public class UserProcessing extends ObjectProcessing {
     }
 
     @Override
-    protected void handleJSONObject(JSONObject user, ResultsHandler handler) {
+    protected boolean handleJSONObject(JSONObject user, ResultsHandler handler) {
         LOG.info("processingObjectFromGET (Object)");
         ConnectorObject connectorObject = convertUserJSONObjectToConnectorObject(
                 saturateGroupMembership(user)
         ).build();
         LOG.info("convertUserToConnectorObject, user: {0}, \n\tconnectorObject: {1}", user.get("id"), connectorObject.toString());
-        handler.handle(connectorObject);
+        return handler.handle(connectorObject);
     }
 
     private JSONObject buildInvitation(Set<Attribute> attributes) {

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/package-info.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/package-info.java
@@ -1,1 +1,1 @@
-package com.evolveum.polygon;
+package com.evolveum.polygon.connector.msgraphapi;

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/BasicConfigurationForTests.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/BasicConfigurationForTests.java
@@ -1,18 +1,24 @@
 package com.evolveum.polygon.connector.msgraphapi.integration;
 
+import java.util.Set;
+
 import com.evolveum.polygon.connector.msgraphapi.MSGraphConfiguration;
 
 public class BasicConfigurationForTests {
 
     private PropertiesParser parser = new PropertiesParser();
     protected String tenantId;
+    protected Set<String> licenses, licenses2;
 
     protected MSGraphConfiguration getConfiguration() {
         MSGraphConfiguration msGraphConfiguration = new MSGraphConfiguration();
         msGraphConfiguration.setClientSecret(parser.getClientSecret());
         msGraphConfiguration.setClientId(parser.getClientId());
         msGraphConfiguration.setTenantId(parser.getTenantId());
+        msGraphConfiguration.setDisabledPlans(parser.getDisabledPlans());
         this.tenantId = parser.getTenantId();
+        this.licenses = parser.getLicenses();
+        this.licenses2 = parser.getLicenses2();
         return msGraphConfiguration;
     }
 

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/LicenseTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/LicenseTest.java
@@ -1,0 +1,202 @@
+package com.evolveum.polygon.connector.msgraphapi.integration;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.identityconnectors.common.CollectionUtil;
+import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.common.security.GuardedString;
+import org.identityconnectors.framework.common.exceptions.UnknownUidException;
+import org.identityconnectors.framework.common.objects.Attribute;
+import org.identityconnectors.framework.common.objects.AttributeBuilder;
+import org.identityconnectors.framework.common.objects.AttributeDelta;
+import org.identityconnectors.framework.common.objects.AttributeDeltaBuilder;
+import org.identityconnectors.framework.common.objects.ConnectorObject;
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.OperationOptions;
+import org.identityconnectors.framework.common.objects.Uid;
+import org.identityconnectors.framework.common.objects.filter.FilterBuilder;
+import org.identityconnectors.test.common.ToListResultsHandler;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.evolveum.polygon.connector.msgraphapi.MSGraphConfiguration;
+import com.evolveum.polygon.connector.msgraphapi.MSGraphConnector;
+
+
+public class LicenseTest extends BasicConfigurationForTests {
+    private static final Log LOG = Log.getLog(LicenseTest.class);
+
+    MSGraphConnector conn;
+    final String nickname = "testing";
+    final String ATTR_LICENSES = "assignedLicenses.skuId";
+    Set<Uid> users = new HashSet<>();
+
+    @BeforeClass
+    public void setUp() {
+        LOG.info("==== setUp ==== ");
+        conn = new MSGraphConnector();
+        MSGraphConfiguration conf = getConfiguration();
+        conn.init(conf);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        users.forEach(uid -> {
+            try {
+                deleteUser(uid);
+            } catch (UnknownUidException e) {}
+        });
+        conn.dispose();
+    }
+
+    Uid createUser(Collection<Attribute> initialAttributes) {
+        LOG.info("creating user, nickname {0}", nickname);
+        Set<Attribute> attributesAccount = new HashSet<>();
+        attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
+        attributesAccount.add(AttributeBuilder.build("displayName", "License Testing"));
+        attributesAccount.add(AttributeBuilder.build("mail", nickname + "@example.com"));
+        attributesAccount.add(AttributeBuilder.build("mailNickname", nickname));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", nickname + "@" + tenantId));
+        attributesAccount.add(AttributeBuilder.build("usageLocation", "US")); // required for licenses
+        GuardedString secret = new GuardedString("SpaghettiMonstersAreReal!".toCharArray());
+        attributesAccount.add(AttributeBuilder.build("__PASSWORD__", secret));
+        if (initialAttributes != null)
+            attributesAccount.addAll(initialAttributes);
+        Uid uid = conn.create(ObjectClass.ACCOUNT, attributesAccount, null);
+        if (uid != null)
+            users.add(uid);
+        return uid;
+    }
+
+    void deleteUser(Uid uid) {
+        LOG.info("deleting user {0}", uid.getUidValue());
+        conn.delete(ObjectClass.ACCOUNT, uid, null);
+        users.remove(uid);
+    }
+
+    ConnectorObject getUser(Uid uid) {
+        ToListResultsHandler handler = new ToListResultsHandler();
+        Map<String,Object> options = new HashMap<>();
+        conn.executeQuery(ObjectClass.ACCOUNT, FilterBuilder.equalTo(uid), handler, new OperationOptions(options));
+        assertNotNull(handler.getObjects(), "result objects");
+        assertEquals(handler.getObjects().size(), 1, "result objects size");
+        return handler.getObjects().get(0);
+    }
+
+    void check(ConnectorObject co, String skuId, boolean has) {
+        Attribute attr = co.getAttributeByName(ATTR_LICENSES);
+        boolean found;
+        if (attr == null)
+            found = false;
+        else
+            found = attr.getValue().stream().anyMatch(it -> skuId.equals(it.toString()));
+        LOG.info("check(co, {0}, {1}) => attr {2}, found {3}", skuId, has, attr, found);
+        if (has)
+            assertTrue(found, "License " + skuId + " should be there");
+        else
+            assertFalse(found, "License " + skuId + " should not be there");
+    }
+
+    @Test
+    public void addRemoveLicenseTest() {
+        LOG.info("==== addRemoveLicenseTest ==== ");
+        if (licenses.isEmpty())
+            throw new SkipException("License skuIds not specified, skipping");
+
+        ConnectorObject co;
+        Set<AttributeDelta> changes;
+
+        Uid uid = createUser(null);
+        Set<AttributeDelta> deltas = new HashSet<>();
+        //String skuId = licenses.stream().findFirst().get();
+        OperationOptions options = new OperationOptions(new HashMap<>());
+
+        LOG.info("==== addRemoveLicenseTest (add) ==== ");
+        deltas.clear();
+        deltas.add(AttributeDeltaBuilder.build("assignedLicenses.skuId", licenses, null));
+        changes = conn.updateDelta(ObjectClass.ACCOUNT, uid, deltas, options);
+        assertTrue(changes == null || changes.isEmpty(), "no side changes");
+        co = getUser(uid);
+        for (String skuId : licenses)
+            check(co, skuId, true);
+
+        LOG.info("==== addRemoveLicenseTest (remove) ==== ");
+        deltas.clear();
+        deltas.add(AttributeDeltaBuilder.build("assignedLicenses.skuId", null, licenses));
+        changes = conn.updateDelta(ObjectClass.ACCOUNT, uid, deltas, options);
+        assertTrue(changes == null || changes.isEmpty(), "no side changes");
+        co = getUser(uid);
+        for (String skuId : licenses)
+            check(co, skuId, false);
+
+        deleteUser(uid);
+    }
+
+    @Test
+    public void createWithLicenseTest() {
+        LOG.info("==== createWithLicenseTest ==== ");
+        if (licenses.isEmpty())
+            throw new SkipException("Licenses not specified, skipping");
+
+        Uid uid;
+        ConnectorObject co;
+
+        Set<Attribute> attributes = new HashSet<>();
+
+        attributes.add(AttributeBuilder.build(ATTR_LICENSES, licenses));
+        uid = createUser(attributes);
+        assertNotNull(uid, "UID of created user");
+        co = getUser(uid);
+        for (String skuId : licenses)
+            check(co, skuId, true);
+
+      deleteUser(uid);
+    }
+
+    @Test
+    public void updateTest() {
+        LOG.info("==== updateTest ==== ");
+        if (licenses.isEmpty())
+            throw new SkipException("Licenses not specified, skipping");
+
+        Uid uid;
+        ConnectorObject co;
+        OperationOptions options = new OperationOptions(new HashMap<>());
+
+        uid = createUser(null);
+        assertNotNull(uid, "UID of created user");
+        co = getUser(uid);
+        for (String skuId : licenses)
+            check(co, skuId, false);
+
+        Set<Attribute> attributes = new HashSet<>();
+        attributes.add(AttributeBuilder.build(ATTR_LICENSES, licenses));
+        conn.update(ObjectClass.ACCOUNT, uid, attributes, options);
+        co = getUser(uid);
+        for (String skuId : licenses)
+            check(co, skuId, true);
+
+        attributes.clear();
+        attributes.add(AttributeBuilder.build(ATTR_LICENSES, licenses2));
+        conn.update(ObjectClass.ACCOUNT, uid, attributes, options);
+        co = getUser(uid);
+        Set<String> removedLicenses = CollectionUtil.newSet(licenses);
+        removedLicenses.removeAll(licenses2);
+        for (String skuId : removedLicenses)
+            check(co, skuId, false);
+        for (String skuId : licenses2)
+            check(co, skuId, true);
+
+        deleteUser(uid);
+    }
+}

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/PropertiesParser.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/PropertiesParser.java
@@ -8,7 +8,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 
 public class PropertiesParser {
@@ -19,6 +22,9 @@ public class PropertiesParser {
     private final String CLIENT_SECRET = "clientSecret";
     private final String CLIENT_ID = "clientID";
     private final String TENANT_ID = "tenantID";
+    private final String LICENSES = "licenses";
+    private final String LICENSES2 = "licenses2";
+    private final String DISABLED_PLANS = "disabledPlans";
 
 
     public PropertiesParser() {
@@ -50,5 +56,27 @@ public class PropertiesParser {
         return new GuardedString(((String) properties.get(CLIENT_SECRET)).toCharArray());
     }
 
+    private Set<String> getValues(String name) {
+        Set<String> values = new HashSet<>();
+        if (properties.containsKey(name)) {
+            String value = (String)properties.get(name);
+            values.addAll(Arrays.asList(value.split(",")));
+        }
+        return values;
+    }
 
+    public Set<String> getLicenses() {
+        return getValues(LICENSES);
+    }
+
+    public Set<String> getLicenses2() {
+        return getValues(LICENSES2);
+    }
+
+    public String[] getDisabledPlans() {
+        if (properties.containsKey(DISABLED_PLANS))
+            return new String[] {(String)properties.get(DISABLED_PLANS)};
+        else
+            return new String[0];
+    }
 }

--- a/testProperties/propertiesforTest.properties
+++ b/testProperties/propertiesforTest.properties
@@ -1,3 +1,8 @@
 clientID=
 clientSecret=
 tenantID=
+
+# optional for license assignment integration testing
+#licenses=SKUID1[,SKUID2...]
+#licenses2=SKUID1[,SKUID2...]
+#disabledPlans=SKUID:SERVICEPLANID1[,SERVICEPLANID2...]


### PR DESCRIPTION
I'm sending the support for license assignments + some two other small changes. Tested with midPoint 3.9.1 and 4.1.

Some notes:
* License assignment operation in Graph API needs the **delta** - it is performed by separate Graph API call "assignLicense", which add or remove licenses. ==&gt; in update operation with the values to replace, it is called the additonal get to fill-in the old values.
* **association** between the _ACCOUNT_ and _license_ is not supported: users has "skuId" as the license list, but uid of license is different (tenantId+_+skuId), and it is not possible to search licenses by "skuId" (I can image some hacks using the tenantId from the autentication, but that probably wouldn't be very nice)
* there is a slight different connector in **midpoint-samples** (_com.evolveum.polygon.connector.msconnector.rest.MSGraphConnector_ instead of _com.evolveum.polygon.connector.msgraphapi.MSGraphConnector_) - is it different connector or it would make sense to update it there?