### PR TITLE
pom.xml not compatible with Maven 3.8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Removed duplicate build plugin entry. Produced warning in Maven 3.6.x and is now an error in Maven 3.8.x