### PR TITLE
Support tenant without SPO license, performance improvement and fix minor bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,15 +82,9 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
-			<version>3.6.0</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20180130</version>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>adal4j</artifactId>
+			<version>1.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
@@ -98,14 +92,9 @@
 			<version>4.4</version>
 		</dependency>
 		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>adal4j</artifactId>
-			<version>1.6.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20180130</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -113,35 +102,43 @@
 			<version>1.6.4</version>
 		</dependency>
 		<dependency>
-			<artifactId>connector-rest</artifactId>
-			<groupId>com.evolveum.polygon</groupId>
-			<version>1.4.2.35</version>
-		</dependency>
-		<dependency>
-			<groupId>net.tirasa.connid</groupId>
-			<artifactId>connector-framework</artifactId>
-			<version>1.4.3.47</version>
-		</dependency>
-		<dependency>
-			<groupId>com.evolveum.polygon</groupId>
-			<artifactId>connector-common</artifactId>
-			<version>1.4.3.47</version>
-		</dependency>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.microsoft.graph</groupId>
-			<artifactId>microsoft-graph</artifactId>
-			<version>1.1.0</version>
+			<version>2.6</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>midpoint</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.evolveum.midpoint.gui</groupId>
+					<artifactId>admin-gui</artifactId>
+					<version>4.3.1</version>
+					<type>jar</type>
+					<classifier>classes</classifier>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+					<version>2.6</version>
+				</dependency>
+				<dependency>
+					<groupId>org.testng</groupId>
+					<artifactId>testng</artifactId>
+					<version>6.8</version>
+					<scope>test</scope>
+					<exclusions>
+						<exclusion>
+							<groupId>org.yaml</groupId>
+							<artifactId>snakeyaml</artifactId>
+						</exclusion>
+					</exclusions>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.6.4</version>
 		</dependency>
+
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
@@ -109,36 +110,4 @@
 		</dependency>
 	</dependencies>
 
-	<profiles>
-		<profile>
-			<id>midpoint</id>
-			<dependencies>
-				<dependency>
-					<groupId>com.evolveum.midpoint.gui</groupId>
-					<artifactId>admin-gui</artifactId>
-					<version>4.3.1</version>
-					<type>jar</type>
-					<classifier>classes</classifier>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
-					<version>2.6</version>
-				</dependency>
-				<dependency>
-					<groupId>org.testng</groupId>
-					<artifactId>testng</artifactId>
-					<version>6.8</version>
-					<scope>test</scope>
-					<exclusions>
-						<exclusion>
-							<groupId>org.yaml</groupId>
-							<artifactId>snakeyaml</artifactId>
-						</exclusion>
-					</exclusions>
-				</dependency>
-			</dependencies>
-		</profile>
-	</profiles>
 </project>

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GraphEndpoint.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GraphEndpoint.java
@@ -36,6 +36,7 @@ import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
@@ -40,8 +40,8 @@ public class GroupProcessing extends ObjectProcessing {
     private static final String ATTR_MEMBERS = "members";
     private static final String ATTR_OWNERS = "owners";
 
-    public GroupProcessing(MSGraphConfiguration configuration, SchemaTranslator schemaTranslator) {
-        super(configuration, schemaTranslator, ICFPostMapper.builder().build());
+    public GroupProcessing(GraphEndpoint graphEndpoint) {
+        super(graphEndpoint, ICFPostMapper.builder().build());
     }
 
 
@@ -169,7 +169,7 @@ public class GroupProcessing extends ObjectProcessing {
         }
 
         Boolean create = uid == null;
-        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        final GraphEndpoint endpoint = getGraphEndpoint();
         final URIBuilder uriBuilder = endpoint.createURIBuilder();
 
         HttpEntityEnclosingRequestBase request = null;
@@ -222,7 +222,7 @@ public class GroupProcessing extends ObjectProcessing {
         HttpDelete request;
         URI uri = null;
 
-        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        final GraphEndpoint endpoint = getGraphEndpoint();
         final URIBuilder uriBuilder = endpoint.createURIBuilder();
         uriBuilder.setPath(GROUPS + "/" + uid.getUidValue());
         uri = endpoint.getUri(uriBuilder);
@@ -391,7 +391,7 @@ public class GroupProcessing extends ObjectProcessing {
 
     private void postRequestNoContent(String path, JSONObject json) {
         LOG.info("path: {0} , json {1}, ", path, json);
-        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        final GraphEndpoint endpoint = getGraphEndpoint();
         final URIBuilder uriBuilder = endpoint.createURIBuilder().setPath(path);
         final URI uri = endpoint.getUri(uriBuilder);
         LOG.info("uri {0}", uri);
@@ -422,7 +422,7 @@ public class GroupProcessing extends ObjectProcessing {
     private void executeDeleteOperation(Uid uid, String path) {
         LOG.info("Delete object, Uid: {0}, Path: {1}", uid, path);
 
-        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        final GraphEndpoint endpoint = getGraphEndpoint();
         final URIBuilder uriBuilder = endpoint.createURIBuilder();
         uriBuilder.setPath(path + "/" + uid.getUidValue() + "/$ref");
 
@@ -436,7 +436,7 @@ public class GroupProcessing extends ObjectProcessing {
 
     public void executeQueryForGroup(Filter query, ResultsHandler handler, OperationOptions options) {
         LOG.info("executeQueryForGroup() Query: {0}", query);
-        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        final GraphEndpoint endpoint = getGraphEndpoint();
         if (query instanceof EqualsFilter) {
             final EqualsFilter equalsFilter = (EqualsFilter) query;
             final String attributeName = equalsFilter.getAttribute().getName();
@@ -489,13 +489,12 @@ public class GroupProcessing extends ObjectProcessing {
     /**
      * Query a group's members and owners, add them to the group's JSON attributes (multivalue)
      *
-     * @param endpoint Graph endpoint to use for querying
      * @param group Group to query for (JSON object resulting from previous API call)
      *
      * @return Original JSON, enriched with member/owner information
      */
     private JSONObject saturateGroupMembership(JSONObject group) {
-        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        final GraphEndpoint endpoint = getGraphEndpoint();
         final String uid = group.getString(ATTR_ID);
         //get list of group members
         final String memberQuery = new StringBuilder()

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
@@ -40,8 +40,8 @@ public class GroupProcessing extends ObjectProcessing {
     private static final String ATTR_MEMBERS = "members";
     private static final String ATTR_OWNERS = "owners";
 
-    public GroupProcessing(MSGraphConfiguration configuration) {
-        super(configuration, ICFPostMapper.builder().build());
+    public GroupProcessing(MSGraphConfiguration configuration, SchemaTranslator schemaTranslator) {
+        super(configuration, schemaTranslator, ICFPostMapper.builder().build());
     }
 
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
@@ -151,11 +151,11 @@ public class GroupProcessing extends ObjectProcessing {
         groupObjClassBuilder.addAttributeInfo(attrVisibility.build());
 
         AttributeInfoBuilder attrMembers = new AttributeInfoBuilder(ATTR_MEMBERS);
-        attrMembers.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true).setMultiValued(true);
+        attrMembers.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true).setMultiValued(true).setReturnedByDefault(false);
         groupObjClassBuilder.addAttributeInfo(attrMembers.build());
 
         AttributeInfoBuilder attrOwners = new AttributeInfoBuilder(ATTR_OWNERS);
-        attrOwners.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true).setMultiValued(true);
+        attrOwners.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true).setMultiValued(true).setReturnedByDefault(false);
         groupObjClassBuilder.addAttributeInfo(attrOwners.build());
 
 
@@ -452,12 +452,12 @@ public class GroupProcessing extends ObjectProcessing {
                 sbPath.append(GROUPS).append("/").append(uid.getUidValue());
 
                 JSONObject group = endpoint.executeGetRequest(sbPath.toString(), null, options, false);
-                handleJSONObject(group, handler);
+                handleJSONObject(options, group, handler);
             } else if (ATTR_DISPLAYNAME.equals(attributeName) || ATTR_MAILNICKNAME.equals(attributeName)) {
                 final String attributeValue = getAttributeFirstValue(equalsFilter);
                 final String customQuery = "$filter=" + attributeName + " eq '" + attributeValue + "'";
                 final JSONObject groups = endpoint.executeGetRequest(GROUPS, customQuery, options, true);
-                handleJSONArray(groups, handler);
+                handleJSONArray(options, groups, handler);
             }
         } else if (query instanceof ContainsFilter) {
             LOG.info("Query is instance of ContainsFilter: {0}", query);
@@ -467,7 +467,7 @@ public class GroupProcessing extends ObjectProcessing {
             if (Arrays.asList(ATTR_DISPLAYNAME, ATTR_MAIL, ATTR_MAILNICKNAME).contains(attributeName)) {
                 String customQuery = "$filter=" + STARTSWITH + "(" + attributeName + ",'" + attributeValue + "')";
                 JSONObject groups = endpoint.executeGetRequest(GROUPS, customQuery, options, true);
-                handleJSONArray(groups, handler);
+                handleJSONArray(options, groups, handler);
             }
         } else if (query instanceof ContainsAllValuesFilter) {
            LOG.info("Query is instance of ContainsAllValuesFilter: {0}", query);
@@ -478,48 +478,54 @@ public class GroupProcessing extends ObjectProcessing {
            String getPath = USERS + "/" + attributeValue + "/memberOf/microsoft.graph.group";
            String customQuery = "$filter=startswith(displayName,'unc:app:aad')&$count=true";
            JSONObject groups = endpoint.executeGetRequest(getPath, customQuery,options,false);
-           handleJSONArray(groups, handler); 
+           handleJSONArray(options, groups, handler);
         } else if (query == null) {
            LOG.info("Query is null");
             JSONObject groups = endpoint.executeGetRequest(GROUPS, null, options, true);
-            handleJSONArray(groups, handler);
+            handleJSONArray(options, groups, handler);
         }
     }
 
     /**
      * Query a group's members and owners, add them to the group's JSON attributes (multivalue)
      *
+     * @param options Operation options
      * @param group Group to query for (JSON object resulting from previous API call)
      *
      * @return Original JSON, enriched with member/owner information
      */
-    private JSONObject saturateGroupMembership(JSONObject group) {
+    private JSONObject saturateGroupMembership(OperationOptions options, JSONObject group) {
         final GraphEndpoint endpoint = getGraphEndpoint();
         final String uid = group.getString(ATTR_ID);
+
         //get list of group members
-        final String memberQuery = new StringBuilder()
-                .append(GROUPS).append("/").append(uid).append("/")
-                .append(ATTR_MEMBERS).toString();
-        final JSONObject groupMembers = endpoint.executeGetRequest(memberQuery, "$select=id,userPrincipalName", null, false);
+        if (getSchemaTranslator().containsToGet(ObjectClass.GROUP_NAME, options, ATTR_MEMBERS)) {
+            final String memberQuery = new StringBuilder()
+                    .append(GROUPS).append("/").append(uid).append("/")
+                    .append(ATTR_MEMBERS).toString();
+            final JSONObject groupMembers = endpoint.executeGetRequest(memberQuery, "$select=id,userPrincipalName", null, false);
+            group.put(ATTR_MEMBERS, getJSONArray(groupMembers, "id"));
+        }
 
         //get list of group owners
-        final String ownerQuery = new StringBuilder()
-                .append(GROUPS).append("/").append(uid).append("/")
-                .append(ATTR_OWNERS).toString();
-        final JSONObject groupOwners = endpoint.executeGetRequest(ownerQuery, "$select=id,userPrincipalName", null, false);
-
-        group.put(ATTR_MEMBERS, getJSONArray(groupMembers, "id"));
-        group.put(ATTR_OWNERS, getJSONArray(groupOwners, "id"));
+        if (getSchemaTranslator().containsToGet(ObjectClass.GROUP_NAME, options, ATTR_OWNERS)) {
+            final String ownerQuery = new StringBuilder()
+                    .append(GROUPS).append("/").append(uid).append("/")
+                    .append(ATTR_OWNERS).toString();
+            final JSONObject groupOwners = endpoint.executeGetRequest(ownerQuery, "$select=id,userPrincipalName", null, false);
+            group.put(ATTR_OWNERS, getJSONArray(groupOwners, "id"));
+        }
 
         return group;
     }
 
     @Override
-    protected boolean handleJSONObject(JSONObject group, ResultsHandler handler) {
+    protected boolean handleJSONObject(OperationOptions options, JSONObject group, ResultsHandler handler) {
         LOG.info("processingObjectFromGET (Object)");
-        final ConnectorObject connectorObject = convertGroupJSONObjectToConnectorObject(
-                saturateGroupMembership(group)
-        ).build();
+        if (!Boolean.TRUE.equals(options.getAllowPartialAttributeValues())) {
+            group = saturateGroupMembership(options, group);
+        }
+        final ConnectorObject connectorObject = convertGroupJSONObjectToConnectorObject(group).build();
         LOG.info("processingGroupObjectFromGET, group: {0}, \n\tconnectorObject: {1}", group.get("id"), connectorObject.toString());
         return handler.handle(connectorObject);
     }

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -119,7 +119,7 @@ public class LicenseProcessing extends ObjectProcessing {
         final GraphEndpoint endpoint = getGraphEndpoint();
         JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS + "/" + skuId, SELECTOR_FULL, options, false);
         LOG.info("JSONObject license {0}", json.toString());
-        handleJSONObject(json, handler);
+        handleJSONObject(options, json, handler);
     }
 
     private void list(ResultsHandler handler, OperationOptions options) {
@@ -129,7 +129,7 @@ public class LicenseProcessing extends ObjectProcessing {
             selector = SELECTOR_PARTIAL;
         JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS, selector, options, false);
         LOG.info("JSONObject license {0}", json.toString());
-        handleJSONArray(json, handler);
+        handleJSONArray(options, json, handler);
     }
 
     public void executeQueryForLicense(Filter query, ResultsHandler handler, OperationOptions options) {
@@ -153,7 +153,7 @@ public class LicenseProcessing extends ObjectProcessing {
     }
 
     @Override
-    protected boolean handleJSONObject(JSONObject json, ResultsHandler handler) {
+    protected boolean handleJSONObject(OperationOptions options, JSONObject json, ResultsHandler handler) {
         ConnectorObjectBuilder builder = new ConnectorObjectBuilder();
         builder.setObjectClass(OBJECT_CLASS);
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -62,8 +62,8 @@ public class LicenseProcessing extends ObjectProcessing {
             ATTR_CONSUMEDUNITS
     );
 
-    public LicenseProcessing(MSGraphConfiguration configuration) {
-        super(configuration, ICFPostMapper.builder().build());
+    public LicenseProcessing(MSGraphConfiguration configuration, SchemaTranslator schemaTranslator) {
+        super(configuration, schemaTranslator, ICFPostMapper.builder().build());
     }
 
     public void buildLicenseObjectClass(SchemaBuilder schemaBuilder) {

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -62,8 +62,8 @@ public class LicenseProcessing extends ObjectProcessing {
             ATTR_CONSUMEDUNITS
     );
 
-    public LicenseProcessing(MSGraphConfiguration configuration, SchemaTranslator schemaTranslator) {
-        super(configuration, schemaTranslator, ICFPostMapper.builder().build());
+    public LicenseProcessing(GraphEndpoint graphEndpoint, SchemaTranslator schemaTranslator) {
+        super(graphEndpoint, ICFPostMapper.builder().build());
     }
 
     public void buildLicenseObjectClass(SchemaBuilder schemaBuilder) {
@@ -116,14 +116,14 @@ public class LicenseProcessing extends ObjectProcessing {
     }
 
     private void get(ResultsHandler handler, String skuId, OperationOptions options) {
-        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        final GraphEndpoint endpoint = getGraphEndpoint();
         JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS + "/" + skuId, SELECTOR_FULL, options, false);
         LOG.info("JSONObject license {0}", json.toString());
         handleJSONObject(json, handler);
     }
 
     private void list(ResultsHandler handler, OperationOptions options) {
-        final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
+        final GraphEndpoint endpoint = getGraphEndpoint();
         String selector = SELECTOR_FULL;
         if (options != null && options.getAllowPartialAttributeValues() != null && options.getAllowPartialAttributeValues())
             selector = SELECTOR_PARTIAL;

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
@@ -82,6 +82,8 @@ public class MSGraphConnector implements Connector,
         LOG.info("Dispose");
 
         configuration = null;
+
+        graphEndpoint.close();
         graphEndpoint = null;
     }
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
@@ -11,7 +11,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.lang.reflect.Array;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -32,9 +31,11 @@ abstract class ObjectProcessing {
 
     private ICFPostMapper postMapper;
     private MSGraphConfiguration configuration;
+    private SchemaTranslator schemaTranslator;
 
-    protected ObjectProcessing(MSGraphConfiguration configuration, ICFPostMapper postMapper) {
+    protected ObjectProcessing(MSGraphConfiguration configuration, SchemaTranslator schemaTranslator, ICFPostMapper postMapper) {
         this.configuration = configuration;
+        this.schemaTranslator = schemaTranslator;
         this.postMapper = postMapper;
     }
 
@@ -44,6 +45,10 @@ abstract class ObjectProcessing {
 
     public MSGraphConfiguration getConfiguration() {
         return configuration;
+    }
+
+    public SchemaTranslator getSchemaTranslator() {
+        return schemaTranslator;
     }
 
     protected void getIfExists(JSONObject object, String attrName, Class<?> type, ConnectorObjectBuilder builder) {
@@ -412,6 +417,7 @@ abstract class ObjectProcessing {
 
     /**
      * Create a selector clause for GraphAPI attributes to list (from field names)
+     *
      * @param fields Names of fields to query
      * @return Selector clause
      */

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
@@ -30,12 +30,10 @@ abstract class ObjectProcessing {
     protected static final String STARTSWITH = "startswith";
 
     private ICFPostMapper postMapper;
-    private MSGraphConfiguration configuration;
-    private SchemaTranslator schemaTranslator;
+    private GraphEndpoint graphEndpoint;
 
-    protected ObjectProcessing(MSGraphConfiguration configuration, SchemaTranslator schemaTranslator, ICFPostMapper postMapper) {
-        this.configuration = configuration;
-        this.schemaTranslator = schemaTranslator;
+    protected ObjectProcessing(GraphEndpoint graphEndpoint, ICFPostMapper postMapper) {
+        this.graphEndpoint = graphEndpoint;
         this.postMapper = postMapper;
     }
 
@@ -43,12 +41,16 @@ abstract class ObjectProcessing {
 
     protected static final Log LOG = Log.getLog(MSGraphConnector.class);
 
-    public MSGraphConfiguration getConfiguration() {
-        return configuration;
+    public GraphEndpoint getGraphEndpoint() {
+        return graphEndpoint;
     }
 
     public SchemaTranslator getSchemaTranslator() {
-        return schemaTranslator;
+        return graphEndpoint.getSchemaTranslator();
+    }
+
+    public MSGraphConfiguration getConfiguration() {
+        return graphEndpoint.getConfiguration();
     }
 
     protected void getIfExists(JSONObject object, String attrName, Class<?> type, ConnectorObjectBuilder builder) {

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
@@ -393,9 +393,9 @@ abstract class ObjectProcessing {
         return false;
     }
 
-    protected abstract boolean handleJSONObject(JSONObject object, ResultsHandler handler);
+    protected abstract boolean handleJSONObject(OperationOptions options, JSONObject object, ResultsHandler handler);
 
-    protected boolean handleJSONArray(JSONObject users, ResultsHandler handler) {
+    protected boolean handleJSONArray(OperationOptions options, JSONObject users, ResultsHandler handler) {
         String jsonStr = users.toString();
         JSONObject jsonObj = new JSONObject(jsonStr);
 
@@ -411,7 +411,7 @@ abstract class ObjectProcessing {
 
         for (int i = 0; i < length; i++) {
             JSONObject user = value.getJSONObject(i);
-            if (!handleJSONObject(user, handler))
+            if (!handleJSONObject(options, user, handler))
                 return false;
         }
         return true;

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
@@ -1,0 +1,84 @@
+package com.evolveum.polygon.connector.msgraphapi;
+
+import org.identityconnectors.framework.common.exceptions.ConnectorException;
+import org.identityconnectors.framework.common.objects.*;
+import org.identityconnectors.framework.spi.operations.SearchOp;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class SchemaTranslator {
+
+    private final Schema rawConnIdSchema;
+    private final Map<String, Map<String, AttributeInfo>> connIdSchema;
+
+    public SchemaTranslator(MSGraphConfiguration configuration) {
+        SchemaBuilder schemaBuilder = new SchemaBuilder(MSGraphConnector.class);
+        UserProcessing userProcessing = new UserProcessing(configuration, this);
+        GroupProcessing groupProcessing = new GroupProcessing(configuration, this);
+        LicenseProcessing licenseProcessing = new LicenseProcessing(configuration, this);
+
+        userProcessing.buildUserObjectClass(schemaBuilder);
+        groupProcessing.buildGroupObjectClass(schemaBuilder);
+        licenseProcessing.buildLicenseObjectClass(schemaBuilder);
+
+        schemaBuilder.defineOperationOption(OperationOptionInfoBuilder.buildAttributesToGet(), SearchOp.class);
+        schemaBuilder.defineOperationOption(OperationOptionInfoBuilder.buildReturnDefaultAttributes(), SearchOp.class);
+
+        rawConnIdSchema = schemaBuilder.build();
+
+        Map<String, Map<String, AttributeInfo>> objectClasses = new HashMap<>();
+
+        for (ObjectClassInfo ocInfo : rawConnIdSchema.getObjectClassInfo()) {
+            Map<String, AttributeInfo> attrs = new HashMap<>();
+            for (AttributeInfo info : ocInfo.getAttributeInfo()) {
+                attrs.put(info.getName(), info);
+            }
+            objectClasses.put(ocInfo.getType(), Collections.unmodifiableMap(attrs));
+        }
+
+        connIdSchema = Collections.unmodifiableMap(objectClasses);
+    }
+
+    public Schema getConnIdSchema() {
+        return rawConnIdSchema;
+    }
+
+    public String[] filter(String type, OperationOptions options, String... attrs) {
+        Set<String> returnedAttributes = getAttributesToGet(type, options);
+
+        String[] filtered = Arrays.stream(attrs)
+                .filter(attr -> returnedAttributes.contains(attr))
+                .toArray(String[]::new);
+
+        return filtered;
+    }
+
+    public Set<String> getAttributesToGet(String type, OperationOptions options) {
+        if (!connIdSchema.containsKey(type)) {
+            throw new ConnectorException("Invalid ObjectClass type: " + type);
+        }
+
+        Set<String> attributesToGet = null;
+        if (Boolean.TRUE.equals(options.getReturnDefaultAttributes())) {
+            attributesToGet = new HashSet<>();
+            attributesToGet.addAll(toReturnedByDefaultAttributesSet(connIdSchema.get(type)));
+        }
+        if (options.getAttributesToGet() != null) {
+            if (attributesToGet == null) {
+                attributesToGet = new HashSet<>();
+            }
+            for (String a : options.getAttributesToGet()) {
+                attributesToGet.add(a);
+            }
+        }
+        return attributesToGet;
+    }
+
+    private static Set<String> toReturnedByDefaultAttributesSet(Map<String, AttributeInfo> attrs) {
+        return attrs.entrySet().stream()
+                .filter(entry -> entry.getValue().isReturnedByDefault())
+                .map(entry -> entry.getKey())
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
@@ -75,6 +75,11 @@ public class SchemaTranslator {
         return attributesToGet;
     }
 
+    public boolean containsToGet(String type, OperationOptions options, String attr) {
+        Set<String> returnedAttributes = getAttributesToGet(type, options);
+        return returnedAttributes.contains(attr);
+    }
+
     private static Set<String> toReturnedByDefaultAttributesSet(Map<String, AttributeInfo> attrs) {
         return attrs.entrySet().stream()
                 .filter(entry -> entry.getValue().isReturnedByDefault())

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
@@ -12,11 +12,11 @@ public class SchemaTranslator {
     private final Schema rawConnIdSchema;
     private final Map<String, Map<String, AttributeInfo>> connIdSchema;
 
-    public SchemaTranslator(MSGraphConfiguration configuration) {
+    public SchemaTranslator(GraphEndpoint graphEndpoint) {
         SchemaBuilder schemaBuilder = new SchemaBuilder(MSGraphConnector.class);
-        UserProcessing userProcessing = new UserProcessing(configuration, this);
-        GroupProcessing groupProcessing = new GroupProcessing(configuration, this);
-        LicenseProcessing licenseProcessing = new LicenseProcessing(configuration, this);
+        UserProcessing userProcessing = new UserProcessing(graphEndpoint, this);
+        GroupProcessing groupProcessing = new GroupProcessing(graphEndpoint);
+        LicenseProcessing licenseProcessing = new LicenseProcessing(graphEndpoint, this);
 
         userProcessing.buildUserObjectClass(schemaBuilder);
         groupProcessing.buildGroupObjectClass(schemaBuilder);

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -1,7 +1,6 @@
 package com.evolveum.polygon.connector.msgraphapi;
 
 import com.evolveum.polygon.common.GuardedStringAccessor;
-
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpPatch;
@@ -20,6 +19,7 @@ import org.json.JSONObject;
 import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 public class UserProcessing extends ObjectProcessing {
@@ -53,7 +53,7 @@ public class UserProcessing extends ObjectProcessing {
 
 
     //optional
-    private static final String ATTR_ABOUTME = "aboutMe";
+    private static final String ATTR_ABOUTME = "aboutMe"; // Need SPO license
 
     //ASSIGNEDLICENSES
     private static final String ATTR_ASSIGNEDLICENSES = "assignedLicenses";
@@ -68,17 +68,17 @@ public class UserProcessing extends ObjectProcessing {
     private static final String ATTR_SERVICE = "service";
     private static final String ATTR_SERVICEPLANID = "servicePlanId";
 
-    private static final String ATTR_BIRTHDAY = "birthday";
+    private static final String ATTR_BIRTHDAY = "birthday"; // Need SPO license
     private static final String ATTR_BUSINESSPHONES = "businessPhones";
     private static final String ATTR_CITY = "city";
     private static final String ATTR_COMPANYNAME = "companyName";
     private static final String ATTR_COUNTRY = "country";
     private static final String ATTR_DEPARTMENT = "department";
     private static final String ATTR_GIVENNAME = "givenName";
-    private static final String ATTR_HIREDATE = "hireDate";
+    private static final String ATTR_HIREDATE = "hireDate"; // Need SPO license
     private static final String ATTR_ID = "id";
     private static final String ATTR_IMADDRESSES = "imAddresses";
-    private static final String ATTR_INTERESTS = "interests";
+    private static final String ATTR_INTERESTS = "interests"; // Need SPO license
     private static final String ATTR_JOBTITLE = "jobTitle";
     private static final String ATTR_MAIL = "mail";
 
@@ -98,25 +98,25 @@ public class UserProcessing extends ObjectProcessing {
 
 
     private static final String ATTR_MOBILEPHONE = "mobilePhone";
-    private static final String ATTR_MYSITE = "mySite";
+    private static final String ATTR_MYSITE = "mySite"; // Need SPO license
     private static final String ATTR_OFFICELOCATION = "officeLocation";
     private static final String ATTR_ONPREMISESLASTSYNCDATETIME = "onPremisesLastSyncDateTime";
     private static final String ATTR_ONPREMISESSECURITYIDENTIFIER = "onPremisesSecurityIdentifier";
     private static final String ATTR_ONPREMISESSYNCENABLED = "onPremisesSyncEnabled";
     private static final String ATTR_PASSWORDPOLICIES = "passwordPolicies";
-    private static final String ATTR_PASTPROJECTS = "pastProjects";
+    private static final String ATTR_PASTPROJECTS = "pastProjects"; // Need SPO license
     private static final String ATTR_POSTALCODE = "postalCode";
     private static final String ATTR_PREFERREDLANGUAGE = "preferredLanguage";
-    private static final String ATTR_PREFERREDNAME = "preferredName";
+    private static final String ATTR_PREFERREDNAME = "preferredName"; // Need SPO license
 
     //provisionplans
     private static final String ATTR_PROVISIONEDPLANS = "provisionedPlans";
     private static final String ATTR_PROVISIONINGSTATUS = "provisioningStatus";
 
     private static final String ATTR_PROXYADDRESSES = "proxyAddresses";
-    private static final String ATTR_RESPONSIBILITIES = "responsibilities";
-    private static final String ATTR_SCHOOLS = "schools";
-    private static final String ATTR_SKILLS = "skills";
+    private static final String ATTR_RESPONSIBILITIES = "responsibilities"; // Need SPO license
+    private static final String ATTR_SCHOOLS = "schools"; // Need SPO license
+    private static final String ATTR_SKILLS = "skills"; // Need SPO license
     private static final String ATTR_STATE = "state";
     private static final String ATTR_STREETADDRESS = "streetAddress";
     private static final String ATTR_SURNAME = "surname";
@@ -140,8 +140,21 @@ public class UserProcessing extends ObjectProcessing {
     private static final String TYPE = "@odata.type";
     private static final String TYPE_GROUP = "#microsoft.graph.group";
 
-    public UserProcessing(MSGraphConfiguration configuration, MSGraphConnector connector) {
-        super(configuration, ICFPostMapper.builder()
+    private static final Set<String> OPTIONAL_ATTRS = Stream.of(
+            ATTR_ABOUTME,
+            ATTR_BIRTHDAY,
+            ATTR_HIREDATE,
+            ATTR_INTERESTS,
+            ATTR_MYSITE,
+            ATTR_PASTPROJECTS,
+            ATTR_PREFERREDNAME,
+            ATTR_RESPONSIBILITIES,
+            ATTR_SCHOOLS,
+            ATTR_SKILLS
+    ).collect(Collectors.toSet());
+
+    public UserProcessing(MSGraphConfiguration configuration, SchemaTranslator schemaTranslator) {
+        super(configuration, schemaTranslator, ICFPostMapper.builder()
                 .remap(ATTR_ICF_PASSWORD, "passwordProfile.password")
                 .postProcess(ATTR_ICF_PASSWORD, pwAttr -> {
                     GuardedString guardedString = (GuardedString) AttributeUtil.getSingleValue(pwAttr);
@@ -213,7 +226,7 @@ public class UserProcessing extends ObjectProcessing {
         userObjClassBuilder.addAttributeInfo(attrOnPremisesImmutableId.build());
 
         AttributeInfoBuilder attrAboutMe = new AttributeInfoBuilder(ATTR_ABOUTME);
-        attrAboutMe.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrAboutMe.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);
         userObjClassBuilder.addAttributeInfo(attrAboutMe.build());
 
 
@@ -265,7 +278,8 @@ public class UserProcessing extends ObjectProcessing {
         AttributeInfoBuilder attrBirthday = new AttributeInfoBuilder(ATTR_BIRTHDAY);
         attrBirthday.setRequired(false)
                 .setType(String.class)
-                .setCreateable(false).setUpdateable(true).setReadable(true);
+                .setCreateable(false).setUpdateable(true).setReadable(true)
+                .setReturnedByDefault(false);
         userObjClassBuilder.addAttributeInfo(attrBirthday.build());
 
         //multivalued but only one number can be set for this property
@@ -301,7 +315,7 @@ public class UserProcessing extends ObjectProcessing {
         userObjClassBuilder.addAttributeInfo(attrGivenName.build());
 
         AttributeInfoBuilder attrHireDate = new AttributeInfoBuilder(ATTR_HIREDATE);
-        attrHireDate.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrHireDate.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);;
         userObjClassBuilder.addAttributeInfo(attrHireDate.build());
 
         //Read-only, not nullable
@@ -311,7 +325,7 @@ public class UserProcessing extends ObjectProcessing {
 
         //multivalued
         AttributeInfoBuilder attrInterests = new AttributeInfoBuilder(ATTR_INTERESTS);
-        attrInterests.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrInterests.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);;
         userObjClassBuilder.addAttributeInfo(attrInterests.build());
 
 
@@ -386,7 +400,7 @@ public class UserProcessing extends ObjectProcessing {
         userObjClassBuilder.addAttributeInfo(attrMobilePhone.build());
 
         AttributeInfoBuilder attrMySite = new AttributeInfoBuilder(ATTR_MYSITE);
-        attrMySite.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrMySite.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);;
         userObjClassBuilder.addAttributeInfo(attrMySite.build());
 
         AttributeInfoBuilder attrOfficeLocation = new AttributeInfoBuilder(ATTR_OFFICELOCATION);
@@ -416,7 +430,7 @@ public class UserProcessing extends ObjectProcessing {
 
         //multivalued
         AttributeInfoBuilder attrPastProjects = new AttributeInfoBuilder(ATTR_PASTPROJECTS);
-        attrPastProjects.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrPastProjects.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);;
         userObjClassBuilder.addAttributeInfo(attrPastProjects.build());
 
         AttributeInfoBuilder attrPostalCode = new AttributeInfoBuilder(ATTR_POSTALCODE);
@@ -428,7 +442,7 @@ public class UserProcessing extends ObjectProcessing {
         userObjClassBuilder.addAttributeInfo(attrPreferredLanguage.build());
 
         AttributeInfoBuilder attrPreferredName = new AttributeInfoBuilder(ATTR_PREFERREDNAME);
-        attrPreferredName.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrPreferredName.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);;
         userObjClassBuilder.addAttributeInfo(attrPreferredName.build());
 
 
@@ -455,17 +469,17 @@ public class UserProcessing extends ObjectProcessing {
 
         //multivalued
         AttributeInfoBuilder attrResponsibilities = new AttributeInfoBuilder(ATTR_RESPONSIBILITIES);
-        attrResponsibilities.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrResponsibilities.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);;
         userObjClassBuilder.addAttributeInfo(attrResponsibilities.build());
 
         //multivalued
         AttributeInfoBuilder attrSchools = new AttributeInfoBuilder(ATTR_SCHOOLS);
-        attrSchools.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrSchools.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);;
         userObjClassBuilder.addAttributeInfo(attrSchools.build());
 
         //multivalued
         AttributeInfoBuilder attrSkills = new AttributeInfoBuilder(ATTR_SKILLS);
-        attrSkills.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true);
+        attrSkills.setRequired(false).setMultiValued(true).setType(String.class).setCreateable(false).setUpdateable(true).setReadable(true).setReturnedByDefault(false);;
         userObjClassBuilder.addAttributeInfo(attrSkills.build());
 
         //supports $filter
@@ -726,18 +740,18 @@ public class UserProcessing extends ObjectProcessing {
     public void executeQueryForUser(Filter query, ResultsHandler handler, OperationOptions options) {
         LOG.info("executeQueryForUser()");
         final GraphEndpoint endpoint = new GraphEndpoint(getConfiguration());
-        final String selectorSingle = selector(
+        final String selectorSingle = selector(getSchemaTranslator().filter(ObjectClass.ACCOUNT_NAME, options,
                 ATTR_ACCOUNTENABLED, ATTR_DISPLAYNAME,
-                        ATTR_ONPREMISESIMMUTABLEID, ATTR_MAILNICKNAME, ATTR_USERPRINCIPALNAME, ATTR_ABOUTME,
-                        ATTR_BIRTHDAY, ATTR_CITY, ATTR_COMPANYNAME, ATTR_COUNTRY, ATTR_DEPARTMENT,
-                        ATTR_GIVENNAME, ATTR_HIREDATE, ATTR_IMADDRESSES, ATTR_ID, ATTR_INTERESTS,
-                        ATTR_JOBTITLE, ATTR_MAIL, ATTR_MOBILEPHONE, ATTR_MYSITE, ATTR_OFFICELOCATION,
-                        ATTR_ONPREMISESLASTSYNCDATETIME, ATTR_ONPREMISESSECURITYIDENTIFIER,
-                        ATTR_ONPREMISESSYNCENABLED, ATTR_PASSWORDPOLICIES, ATTR_PASTPROJECTS,
-                        ATTR_POSTALCODE, ATTR_PREFERREDLANGUAGE, ATTR_PREFERREDNAME,
-                        ATTR_PROXYADDRESSES, ATTR_RESPONSIBILITIES, ATTR_SCHOOLS,
-                        ATTR_SKILLS, ATTR_STATE, ATTR_STREETADDRESS, ATTR_SURNAME,
-                        ATTR_USAGELOCATION, ATTR_USERTYPE, ATTR_ASSIGNEDLICENSES);
+                ATTR_ONPREMISESIMMUTABLEID, ATTR_MAILNICKNAME, ATTR_USERPRINCIPALNAME, ATTR_ABOUTME,
+                ATTR_BIRTHDAY, ATTR_CITY, ATTR_COMPANYNAME, ATTR_COUNTRY, ATTR_DEPARTMENT,
+                ATTR_GIVENNAME, ATTR_HIREDATE, ATTR_IMADDRESSES, ATTR_ID, ATTR_INTERESTS,
+                ATTR_JOBTITLE, ATTR_MAIL, ATTR_MOBILEPHONE, ATTR_MYSITE, ATTR_OFFICELOCATION,
+                ATTR_ONPREMISESLASTSYNCDATETIME, ATTR_ONPREMISESSECURITYIDENTIFIER,
+                ATTR_ONPREMISESSYNCENABLED, ATTR_PASSWORDPOLICIES, ATTR_PASTPROJECTS,
+                ATTR_POSTALCODE, ATTR_PREFERREDLANGUAGE, ATTR_PREFERREDNAME,
+                ATTR_PROXYADDRESSES, ATTR_RESPONSIBILITIES, ATTR_SCHOOLS,
+                ATTR_SKILLS, ATTR_STATE, ATTR_STREETADDRESS, ATTR_SURNAME,
+                ATTR_USAGELOCATION, ATTR_USERTYPE, ATTR_ASSIGNEDLICENSES));
 
         final String selectorList = selector(
                 ATTR_ACCOUNTENABLED, ATTR_DISPLAYNAME,

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -634,17 +634,17 @@ public class UserProcessing extends ObjectProcessing {
 
         final GraphEndpoint endpoint = getGraphEndpoint();
 
-        final String emailAddress = attributes.stream()
+        final Optional<String> emailAddress = attributes.stream()
                 .filter(a -> a.is(ATTR_MAIL))
                 .map(a -> a.getValue().get(0).toString())
-                .findFirst().get();
+                .findFirst();
 
         final boolean hasUPN = attributes.stream()
                 .filter(a -> a.is(ATTR_USERPRINCIPALNAME))
                 .anyMatch(a -> !a.getValue().isEmpty());
 
 
-        final boolean invite = !emailAddress.split("@")[1].equals(getConfiguration().getTenantId()) &&
+        final boolean invite = emailAddress.isPresent() && !emailAddress.get().split("@")[1].equals(getConfiguration().getTenantId()) &&
                 getConfiguration().isInviteGuests() &&
                 !hasUPN;
 

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessingTest.java
@@ -24,7 +24,7 @@ public class GroupProcessingTest {
         }
     }
 
-    final GroupProcessing groupProcessing = new GroupProcessing(new MSGraphConfiguration());
+    final GroupProcessing groupProcessing = new GroupProcessing(new MSGraphConfiguration(), new SchemaTranslator(new MSGraphConfiguration()));
 
     @Test
     public void testParseGroupMembers() throws Exception {

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessingTest.java
@@ -2,6 +2,7 @@ package com.evolveum.polygon.connector.msgraphapi;
 
 import com.evolveum.polygon.connector.msgraphapi.GroupProcessing;
 import com.evolveum.polygon.connector.msgraphapi.MSGraphConfiguration;
+import com.evolveum.polygon.connector.msgraphapi.integration.BasicConfigurationForTests;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -16,7 +17,7 @@ import java.util.List;
  * Test case for {@link GroupProcessing}
  */
 @Test(groups = "unit")
-public class GroupProcessingTest {
+public class GroupProcessingTest extends BasicConfigurationForTests {
 
     private JSONObject parseResource(String fileName) throws IOException  {
         try (InputStream is = getClass().getResourceAsStream(fileName)) {
@@ -24,7 +25,7 @@ public class GroupProcessingTest {
         }
     }
 
-    final GroupProcessing groupProcessing = new GroupProcessing(new MSGraphConfiguration(), new SchemaTranslator(new MSGraphConfiguration()));
+    final GroupProcessing groupProcessing = new GroupProcessing(new GraphEndpoint(getConfiguration()));
 
     @Test
     public void testParseGroupMembers() throws Exception {

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/PropertiesParser.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/PropertiesParser.java
@@ -18,7 +18,7 @@ public class PropertiesParser {
 
     private static final Log LOGGER = Log.getLog(PropertiesParser.class);
     private Properties properties;
-    private String FilePath = "../connector-msgraph/testProperties/propertiesforTest.properties";
+    private String FilePath = "./testProperties/propertiesforTest.properties";
     private final String CLIENT_SECRET = "clientSecret";
     private final String CLIENT_ID = "clientID";
     private final String TENANT_ID = "tenantID";

--- a/testProperties/propertiesforTest.properties
+++ b/testProperties/propertiesforTest.properties
@@ -1,6 +1,6 @@
-clientID=
-clientSecret=
-tenantID=
+clientID=aa
+clientSecret=aaa
+tenantID=aaa
 
 # optional for license assignment integration testing
 #licenses=SKUID1[,SKUID2...]


### PR DESCRIPTION
This pull request includes several improvement.

## Support tenant without SPO license

Current implementation can't fetch user attributes because it always tries to fetch some attributes which requires SPO license.
To support non-SPO license tenant, I made the attributes that require SPO license optional (`returnedByDefault=false`).

Note: Now we need to set `fetchStrategy` as `explicit` to fetch the attributes requires SPO license, .
```
            <attribute>
                <ref>ri:aboutMe</ref>
                <fetchStrategy>explicit</fetchStrategy>
                ...
            </attribute>
```

## Performance Improvement

I noticed that there is room to improve performance.

- Cache access token. Currently, the connector requests the token for every operations.  Now changed it's cached until it expires - 5 minutes.
- Suppress association fetching. Currently, the connector fetches group membership always.  Now it only fetches them when requested. (Note: Need to set `fetchStrategy` as `explicit`)
- Reuse httpClient for each pooled instance of the connector to reduce TLS handshake overhead.

## Fix minor bug

- Remove unnecessary dependencies.
- Fix NoSuchElementException when creating a user without email.
- Fix error handling when authentication fails.
