### PR TITLE
Fix "attributes to get" feature for container attributes

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
@@ -46,9 +46,15 @@ public class SchemaTranslator {
 
     public String[] filter(String type, OperationOptions options, String... attrs) {
         Set<String> returnedAttributes = getAttributesToGet(type, options);
+        Set<String> returnedContainerAttributes = returnedAttributes.stream()
+                .filter(attr -> attr.contains("."))
+                .map(attr -> attr.substring(0, attr.indexOf(".")))
+                .distinct()
+                .collect(Collectors.toSet());
 
         String[] filtered = Arrays.stream(attrs)
-                .filter(attr -> returnedAttributes.contains(attr))
+                .filter(attr -> returnedAttributes.contains(attr)
+                        || returnedContainerAttributes.contains(attr))
                 .toArray(String[]::new);
 
         return filtered;


### PR DESCRIPTION
Filtering of the attributes to get for MSGraph API in the PR #12 doesn't handle structure attributes like `assignedLicenses`. This PR adds support for it.

This is important for example for managing user licences (fetching `assignedLicenses.skuId` user attribute).