### PR TITLE
fixes filtering out all schema attributes

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
@@ -47,27 +47,21 @@ public class SchemaTranslator {
     }
 
     public String[] filter(String type, OperationOptions options, String... attrs) {
-/// TODO check invalid state in case operation options return no "get attributes to get"
         Set<String> returnedAttributes = getAttributesToGet(type, options);
-        Set<String> returnedContainerAttributes= new HashSet<>();
-        String[] filtered = null;
-        if (returnedAttributes != null) {
 
-            returnedContainerAttributes = returnedAttributes.stream()
-                    .filter(attr -> attr.contains("."))
-                    .map(attr -> attr.substring(0, attr.indexOf(".")))
-                    .distinct()
-                    .collect(Collectors.toSet());
-
+        if (returnedAttributes.isEmpty()) {
+            return attrs;
         }
-            Set<String> finalReturnedContainerAttributes = returnedContainerAttributes;
 
-            filtered = Arrays.stream(attrs)
-                    .filter(attr -> returnedAttributes.contains(attr)
-                            || finalReturnedContainerAttributes.contains(attr))
-                    .toArray(String[]::new);
+        Set<String> returnedContainerAttributes = returnedAttributes.stream()
+                .filter(attr -> attr.contains("."))
+                .map(attr -> attr.substring(0, attr.indexOf(".")))
+                .collect(Collectors.toSet());
 
-        return filtered;
+        return Arrays.stream(attrs)
+                .filter(attr -> returnedAttributes.contains(attr)
+                        || returnedContainerAttributes.contains(attr))
+                .toArray(String[]::new);
     }
 
     public Set<String> getAttributesToGet(String type, OperationOptions options) {
@@ -75,15 +69,11 @@ public class SchemaTranslator {
             throw new ConnectorException("Invalid ObjectClass type: " + type);
         }
 
-        Set<String> attributesToGet = null;
+        Set<String> attributesToGet = new HashSet<>();
         if (Boolean.TRUE.equals(options.getReturnDefaultAttributes())) {
-            attributesToGet = new HashSet<>();
             attributesToGet.addAll(toReturnedByDefaultAttributesSet(connIdSchema.get(type)));
         }
         if (options.getAttributesToGet() != null) {
-            if (attributesToGet == null) {
-                attributesToGet = new HashSet<>();
-            }
             for (String a : options.getAttributesToGet()) {
                 attributesToGet.add(a);
             }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslatorFilterTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslatorFilterTest.java
@@ -1,0 +1,40 @@
+package com.evolveum.polygon.connector.msgraphapi;
+
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.OperationOptions;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+@Test(groups = "unit")
+public class SchemaTranslatorFilterTest {
+    SchemaTranslator schemaTranslator = new SchemaTranslator(null);
+
+    @Test
+    void testFilterWithAttrToGetOperationOptions() {
+        OperationOptions options = new OperationOptions(Collections.singletonMap(OperationOptions.OP_ATTRIBUTES_TO_GET, new String[]{"attr1"}));
+        String[] attrs = schemaTranslator.filter(ObjectClass.ACCOUNT_NAME, options, "attr1", "attr2");
+
+        Assert.assertEquals(1, attrs.length);
+        Assert.assertEquals("attr1", attrs[0]);
+    }
+
+    @Test
+    void testFilterWithReturnDefaultAttrsOperationOptions() {
+        OperationOptions options = new OperationOptions(Collections.singletonMap(OperationOptions.OP_RETURN_DEFAULT_ATTRIBUTES, true));
+        String[] attrs = schemaTranslator.filter(ObjectClass.ACCOUNT_NAME, options, "attr");
+
+        // no attributes are define in schema
+        Assert.assertEquals(0, attrs.length);
+    }
+
+    @Test
+    void testEmptyFilter() {
+        OperationOptions options = new OperationOptions(Collections.emptyMap());
+        String[] attrs = schemaTranslator.filter(ObjectClass.ACCOUNT_NAME, options, "attr");
+
+        Assert.assertEquals(1, attrs.length);
+        Assert.assertEquals("attr", attrs[0]);
+    }
+}


### PR DESCRIPTION
Hello,
we had a problem with NPE first, when wanted to create/update user. It had been fixed before I started preparing our PR. But still we were not able to sync all attributes. I have refactored solution a little and also fixed the problem on empty filtering rules.

I am sorry I wasn't able to run existing tests, We have only one office 365 instance, and it looks scary to run tests on it. If there is a way, let me know, I will try & update tests.

Jakub