### PR TITLE
Fixed unwanted licence removal when modifying user

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -19,6 +19,7 @@ import org.json.JSONObject;
 
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -546,17 +547,26 @@ public class UserProcessing extends ObjectProcessing {
         AttributeDeltaBuilder delta = new AttributeDeltaBuilder();
         delta.setName(ATTR_ASSIGNEDLICENSES__SKUID);
         List<Object> addLicenses = new ArrayList<>();
+
+        AtomicBoolean isLicenceAttrNull = new AtomicBoolean(true);
         // filter out the assignedLicense.skuId attribute, which must be handled separately
         Set<Attribute> preparedAttributes = replaceAttributes.stream()
                 .filter(it -> {
                     if (it.getName().equals(ATTR_ASSIGNEDLICENSES__SKUID)) {
                         if (it.getValue() != null)
-                            addLicenses.addAll(it.getValue());
+                            isLicenceAttrNull.set(false);
+                        addLicenses.addAll(it.getValue());
                         return false;
                     } else
                         return true;
                 })
                 .collect(Collectors.toSet());
+
+        // in case assignedLicences attribute is null we don't want to do anything with licences
+        if (isLicenceAttrNull.get()) {
+            return preparedAttributes;
+        }
+
         delta.addValueToAdd(addLicenses);
         // read and fill-out the old values
         if (!create) {
@@ -608,6 +618,10 @@ public class UserProcessing extends ObjectProcessing {
     }
 
     private void assignLicenses(Uid uid, AttributeDelta deltaLicense) {
+        if (deltaLicense == null) {
+            return;
+        }
+
         final List<Object> addLicenses = deltaLicense.getValuesToAdd();
         final List<Object> removeLicenses = deltaLicense.getValuesToRemove();
         if ((addLicenses == null || addLicenses.isEmpty()) && (removeLicenses == null || removeLicenses.isEmpty()))

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -553,9 +553,10 @@ public class UserProcessing extends ObjectProcessing {
         Set<Attribute> preparedAttributes = replaceAttributes.stream()
                 .filter(it -> {
                     if (it.getName().equals(ATTR_ASSIGNEDLICENSES__SKUID)) {
-                        if (it.getValue() != null)
+                        if (it.getValue() != null) {
                             isLicenceAttrNull.set(false);
-                        addLicenses.addAll(it.getValue());
+                            addLicenses.addAll(it.getValue());
+                        }
                         return false;
                     } else
                         return true;


### PR DESCRIPTION
This pull request contains a fix of update user operation.

Reason to fix: modification of user attributes unrelated to licences leads to unexpected changes in licence assignments.

When updating user, connector assumes that licences which are assigned to MS Graph account but don't exist in assignedLicences.skuId attribute delta should be unassigned. However, this should be the case only if delta contains (an empty) list as a replace value, not when the delta doesn't even exist.


