### PR TITLE
feat: added role membership management (assign/unassign roles) to user - designed for Czech Post v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ This are permissions which you need to add to your Azure Active Directory applic
 ###For SharePoint you need also:
 * User.Read.All -> Delegated permission
 * User.ReadWrite.All -> Delegated permission
+###For Role membership management you need also:
+* EntitlementManagement.Read.All -> Application permission 
+* EntitlementManagement.ReadWrite.All -> Application permission 
+* RoleManagement.Read.Directory -> Application permission 
+* RoleManagement.ReadWrite.Directory -> Application permission
 
 ##Resource Examples
 * AAD-resource.xml - sample resource.

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
@@ -106,6 +106,10 @@ public class MSGraphConnector implements Connector,
             GroupProcessing groupProcessing = new GroupProcessing(getGraphEndpoint());
             return groupProcessing.createOrUpdateGroup(null, attributes);
 
+        } else if (objectClass.is(RoleProcessing.ROLE_NAME)) {
+            RoleProcessing roleProcessing = new RoleProcessing(getGraphEndpoint());
+            return roleProcessing.createOrUpdateRole(null, attributes);
+
         } else {
             throw new UnsupportedOperationException("Unsupported object class " + objectClass);
         }
@@ -134,6 +138,10 @@ public class MSGraphConnector implements Connector,
         } else if (objectClass.is(ObjectClass.GROUP_NAME)) {
             GroupProcessing group = new GroupProcessing(getGraphEndpoint());
             group.delete(uid);
+
+        } else if (objectClass.is(RoleProcessing.ROLE_NAME)) {
+            RoleProcessing role = new RoleProcessing(getGraphEndpoint());
+            role.delete(uid);
 
         }
     }
@@ -305,6 +313,9 @@ public class MSGraphConnector implements Connector,
         } else if (objectClass.is(LicenseProcessing.OBJECT_CLASS_NAME)) {
             LicenseProcessing licenseProcessing = new LicenseProcessing(getGraphEndpoint(), getSchemaTranslator());
             licenseProcessing.executeQueryForLicense(query, handler, options);
+        } else if (objectClass.is(RoleProcessing.ROLE_NAME)) {
+            RoleProcessing roleProcessing = new RoleProcessing(getGraphEndpoint());
+            roleProcessing.executeQueryForRole(query, handler, options);
         } else {
             LOG.error("Attribute of type ObjectClass is not supported.");
             throw new UnsupportedOperationException("Attribute of type ObjectClass is not supported.");
@@ -374,6 +385,13 @@ public class MSGraphConnector implements Connector,
             if (!attrsDeltaMultivalue.isEmpty()) {
                 new GroupProcessing(getGraphEndpoint()).updateDeltaMultiValuesForGroup(uid, attrsDeltaMultivalue, options);
             }
+        } else if (objectClass.is(RoleProcessing.ROLE_NAME)) { // __ROLE__
+            if (!attributeReplace.isEmpty()) {
+                new RoleProcessing(getGraphEndpoint()).createOrUpdateRole(uid, attributeReplace);
+            }
+            if (!attrsDeltaMultivalue.isEmpty()) {
+                new RoleProcessing(getGraphEndpoint()).updateDeltaMultiValuesForRole(uid, attrsDeltaMultivalue, options);
+            }
         } else {
             LOG.error("The value of the ObjectClass parameter is unsupported.");
             throw new UnsupportedOperationException("The value of the ObjectClass parameter is unsupported.");
@@ -392,6 +410,10 @@ public class MSGraphConnector implements Connector,
         if (objectClass.is(ObjectClass.GROUP_NAME)) {
             GroupProcessing groupProcessing = new GroupProcessing(getGraphEndpoint());
             groupProcessing.addToGroup(uid, attributes);
+
+        } else if (objectClass.is(RoleProcessing.ROLE_NAME)) {
+            RoleProcessing roleProcessing = new RoleProcessing(getGraphEndpoint());
+            roleProcessing.addToRole(uid, attributes);
 
         }
 
@@ -416,6 +438,11 @@ public class MSGraphConnector implements Connector,
         if (objectClass.is(ObjectClass.GROUP_NAME)) {
             GroupProcessing groupProcessing = new GroupProcessing(getGraphEndpoint());
             groupProcessing.removeFromGroup(uid, attributes);
+
+        } else if (objectClass.is(RoleProcessing.ROLE_NAME)) {
+            RoleProcessing roleProcessing = new RoleProcessing(getGraphEndpoint());
+            roleProcessing.removeFromRole(uid, attributes, operationOptions);
+
         }
 
         return uid;
@@ -437,7 +464,13 @@ public class MSGraphConnector implements Connector,
         } else if (objectClass.is(ObjectClass.GROUP_NAME)) {
             GroupProcessing groupProcessing = new GroupProcessing(getGraphEndpoint());
             groupProcessing.createOrUpdateGroup(uid, attributes);
+
+        } else if (objectClass.is(RoleProcessing.ROLE_NAME)) {
+            RoleProcessing roleProcessing = new RoleProcessing(getGraphEndpoint());
+            roleProcessing.createOrUpdateRole(uid, attributes);
+
         }
+
         return uid;
     }
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
@@ -63,6 +63,19 @@ abstract class ObjectProcessing {
         }
     }
 
+    protected void getRoleInheritPermissionsIfExists(JSONObject object, String attrName, Class<?> type, ConnectorObjectBuilder builder) {
+        if (object.has(attrName) && object.get(attrName) != null && !JSONObject.NULL.equals(object.get(attrName)) && !String.valueOf(object.get(attrName)).isEmpty()) {
+            if (type.equals(String.class)) {
+                String attrValue = String.valueOf(object.get(attrName));
+                attrValue = attrValue.replaceFirst("https://graph.microsoft.com/v1.0/\\$metadata#roleManagement/directory/roleDefinitions\\('", "");
+                attrValue = attrValue.replaceFirst("'\\)/inheritsPermissionsFrom", "");
+                addAttr(builder, attrName, attrValue);
+            } else {
+                addAttr(builder, attrName, object.get(attrName));
+            }
+        }
+    }
+
     protected void getAndRenameIfExists(JSONObject object, String jsonAttrName, Class<?> type, String icfAttrName, ConnectorObjectBuilder builder) {
         if (object.has(jsonAttrName) && object.get(jsonAttrName) != null && !JSONObject.NULL.equals(object.get(jsonAttrName)) && !String.valueOf(object.get(jsonAttrName)).isEmpty()) {
             if (type.equals(String.class)) {
@@ -110,6 +123,35 @@ abstract class ObjectProcessing {
         }
     }
 
+    protected Object getIdFromAssignmentObject(JSONObject object, String attrName, Class<?> type) {
+        JSONArray value;
+
+        try {
+            value = object.getJSONArray("value");
+        } catch (JSONException e) {
+            LOG.info("No objects in JSON Array");
+            return null;
+        }
+
+        int length = value.length();
+        LOG.info("JSON Object length: {0}", length);
+
+        if (length == 1) {
+            JSONObject assignmentObject = value.getJSONObject(0);
+            if (assignmentObject.has(attrName) && assignmentObject.get(attrName) != null && !JSONObject.NULL.equals(assignmentObject.get(attrName)) && !String.valueOf(assignmentObject.get(attrName)).isEmpty()) {
+                if (type.equals(String.class))
+                    return String.valueOf(assignmentObject.get(attrName));
+                else
+                    return assignmentObject.get(attrName);
+            } else {
+                return null;
+            }
+        } else {
+            LOG.info("JSON Object should have size exactly 1");
+            return null;
+        }
+    }
+
     protected void getFromItemIfExists(JSONObject object, String attrName, String subAttrName, Class<?> type, ConnectorObjectBuilder builder) {
         if (object.has(attrName)) {
             Object valueObject = object.get(attrName);
@@ -135,6 +177,42 @@ abstract class ObjectProcessing {
                         }
                     });
                     builder.addAttribute(attrName + "." + subAttrName, values.toArray());
+                }
+            }
+        }
+    }
+
+    protected void getRolePermissionsIfExists(JSONObject object, String attrName, String subAttrName, Class<?> type, ConnectorObjectBuilder builder) {
+        if (object.has(attrName)) {
+            Object valueObject = object.get(attrName);
+            if (valueObject != null && !JSONObject.NULL.equals(valueObject)) {
+                if (valueObject instanceof JSONArray) {
+                    JSONArray objectArray = (JSONArray)valueObject;
+                    List<String> workingValues = new ArrayList<>();
+                    List<String> returnValues = new ArrayList<>();
+                    objectArray.forEach(it -> {
+                        if (it instanceof JSONObject) {
+                            String subValue = (String) getValueFromItem((JSONObject)it, subAttrName, type);
+                            String conditionValue = (String) getValueFromItem((JSONObject)it, "condition", type);
+                            if (subValue != null)
+                                workingValues.addAll(
+                                        Arrays.asList(
+                                                subValue.replaceAll("\\[", "")
+                                                        .replaceAll("\\]", "")
+                                                        .replaceAll("\"", "")
+                                                        .split(",")
+                                        )
+                                );
+
+                            returnValues.addAll(workingValues.stream().map( value -> {
+                                if (conditionValue != null)
+                                    return  conditionValue + "|" + value;
+                                else
+                                    return value;
+                            }).collect(Collectors.toList()));
+                        }
+                    });
+                    builder.addAttribute(attrName + "." + subAttrName, returnValues.toArray());
                 }
             }
         }
@@ -202,6 +280,11 @@ abstract class ObjectProcessing {
     protected final JSONArray getJSONArray(JSONObject objectCollection, String attribute) {
         final JSONArray arr = objectCollection.getJSONArray("value");
         return new JSONArray(arr.toList().stream().map(i -> ((Map) i).get(attribute)).collect(Collectors.toList()));
+    }
+
+    protected final ArrayList<String> getArrayList(JSONObject objectCollection, String attribute) {
+        final JSONArray arr = objectCollection.getJSONArray("value");
+        return arr.toList().stream().map(i -> ((Map) i).get(attribute)).map(Object::toString).collect(Collectors.toCollection(ArrayList::new));
     }
 
     protected void invalidAttributeValue(String attrName, Filter query) {
@@ -424,12 +507,12 @@ abstract class ObjectProcessing {
      * @return Selector clause
      */
     protected static String selector(String... fields) {
-        if ( fields == null || fields.length <= 0)
+        if (fields == null || fields.length == 0)
             throw new ConfigurationException("Connector selector query is badly configured. This is likely a programming error.");
         if (Arrays.stream(fields).anyMatch(f ->
                 f == null || "".equals(f) || f.contains("&") || f.contains("?") || f.contains("$") || f.contains("=")
         )) throw new ConfigurationException("Connector selector fields contain invalid characters. This is likely a programming error.");
-        return "$select=" + Arrays.stream(fields).collect(Collectors.joining(","));
+        return "$select=" + String.join(",", fields);
     }
 
 }

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessing.java
@@ -1,0 +1,438 @@
+package com.evolveum.polygon.connector.msgraphapi;
+
+import org.apache.http.client.methods.*;
+import org.apache.http.client.utils.URIBuilder;
+import org.identityconnectors.framework.common.objects.*;
+import org.identityconnectors.framework.common.objects.filter.ContainsAllValuesFilter;
+import org.identityconnectors.framework.common.objects.filter.ContainsFilter;
+import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
+import org.identityconnectors.framework.common.objects.filter.Filter;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.net.URI;
+import java.util.*;
+
+public class RoleProcessing extends ObjectProcessing {
+    public static final String ROLE_NAME = "Role";
+    public static final ObjectClass ROLE = new ObjectClass(ROLE_NAME);
+
+    private final static String ROLES = "/roleManagement/directory/roleDefinitions";
+    private final static String ROLE_ASSIGNMENT = "/roleManagement/directory/roleAssignments";
+    private final static String USERS = "/users";
+
+    private static final String ATTR_ID = "id";
+    private static final String ATTR_DESCRIPTION = "description";
+    private static final String ATTR_DISPLAY_NAME = "displayName";
+    private static final String ATTR_IS_BUILT_IN = "isBuiltIn";
+    private static final String ATTR_IS_ENABLED = "isEnabled";
+    private static final String ATTR_RESOURCE_SCOPES = "resourceScopes";
+    private static final String ATTR_TEMPLATE_ID = "templateId";
+    private static final String ATTR_VERSION = "version";
+    private static final String ATTR_ROLE_PERMISSIONS = "rolePermissions";
+    private static final String ATTR_ALLOWED_RESOURCE_ACTIONS = "allowedResourceActions";
+    private static final String ATTR_ROLE_PERMISSIONS_ALL = ATTR_ROLE_PERMISSIONS + "." + ATTR_ALLOWED_RESOURCE_ACTIONS;
+    private static final String ATTR_INHERIT_PERMISSIONS_FROM_ODATA_CONTEXT = "inheritsPermissionsFrom@odata.context";
+    private static final String ATTR_INHERIT_PERMISSIONS_FROM = "inheritsPermissionsFrom";
+    private static final String ATTR_INHERIT_PERMISSIONS_FROM_ALL = ATTR_INHERIT_PERMISSIONS_FROM + "." + ATTR_ID;
+
+
+    private static final String ATTR_MEMBERS = "members";
+
+    public RoleProcessing(GraphEndpoint graphEndpoint) {
+        super(graphEndpoint, ICFPostMapper.builder().build());
+    }
+
+
+    public void buildRoleObjectClass(SchemaBuilder schemaBuilder) {
+        schemaBuilder.defineObjectClass(objectClassInfo());
+    }
+
+    @Override
+    protected ObjectClassInfo objectClassInfo() {
+        ObjectClassInfoBuilder roleObjClassBuilder = new ObjectClassInfoBuilder();
+
+        roleObjClassBuilder.setType(RoleProcessing.ROLE_NAME);
+
+        // required attribute is icfs:name and icfs:uid
+
+        // optional
+
+        // read-only
+        AttributeInfoBuilder attrIsEnabled = new AttributeInfoBuilder(ATTR_IS_ENABLED);
+        attrIsEnabled.setType(Boolean.class).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrIsEnabled.build());
+
+        // read-only
+        AttributeInfoBuilder attrIsBuiltIn = new AttributeInfoBuilder(ATTR_IS_BUILT_IN);
+        attrIsBuiltIn.setRequired(false).setType(Boolean.class).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrIsBuiltIn.build());
+
+        // read-only
+        AttributeInfoBuilder attrTemplateId = new AttributeInfoBuilder(ATTR_TEMPLATE_ID);
+        attrTemplateId.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrTemplateId.build());
+
+        // read-only
+        AttributeInfoBuilder attrVersion = new AttributeInfoBuilder(ATTR_VERSION);
+        attrVersion.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrVersion.build());
+
+        // read-only
+        AttributeInfoBuilder attrDescription = new AttributeInfoBuilder(ATTR_DESCRIPTION);
+        attrDescription.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrDescription.build());
+
+        // multivalued, read-only
+        AttributeInfoBuilder attrResourceScopes = new AttributeInfoBuilder(ATTR_RESOURCE_SCOPES);
+        attrResourceScopes.setRequired(false).setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrResourceScopes.build());
+
+        // multivalued, read-only
+        AttributeInfoBuilder attrRolePermissionsAll = new AttributeInfoBuilder(ATTR_ROLE_PERMISSIONS_ALL);
+        attrRolePermissionsAll.setRequired(false).setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrRolePermissionsAll.build());
+
+        // read-only
+        AttributeInfoBuilder attrInheritPermissionsFromDataContext = new AttributeInfoBuilder(ATTR_INHERIT_PERMISSIONS_FROM_ODATA_CONTEXT);
+        attrInheritPermissionsFromDataContext.setRequired(false).setType(String.class).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrInheritPermissionsFromDataContext.build());
+
+        // multivalued, read-only
+        AttributeInfoBuilder attrInheritPermissionsFromAll = new AttributeInfoBuilder(ATTR_INHERIT_PERMISSIONS_FROM_ALL);
+        attrInheritPermissionsFromAll.setRequired(false).setType(String.class).setMultiValued(true).setCreateable(false).setUpdateable(false).setReadable(true);
+        roleObjClassBuilder.addAttributeInfo(attrInheritPermissionsFromAll.build());
+
+        // multivalued, read-only
+        AttributeInfoBuilder attrMembers = new AttributeInfoBuilder(ATTR_MEMBERS);
+        attrMembers.setType(String.class).setCreateable(true).setUpdateable(true).setReadable(true).setMultiValued(true).setReturnedByDefault(false);
+        roleObjClassBuilder.addAttributeInfo(attrMembers.build());
+
+
+        return roleObjClassBuilder.build();
+    }
+
+    protected Uid createOrUpdateRole(Uid uid, Set<Attribute> attributes) {
+        throw new UnsupportedOperationException("Create/Update operation is not supported for Roles!");
+    }
+
+    protected void delete(Uid uid) {
+        throw new UnsupportedOperationException("Delete operation is not supported for Roles!");
+    }
+
+
+    protected void updateDeltaMultiValuesForRole(Uid uid, Set<AttributeDelta> attributesDelta, OperationOptions options) {
+        LOG.info("updateDeltaMultiValuesForRole on uid: {0}, attrDelta: {1}, options: {2}", uid.getValue(), attributesDelta, options);
+        for (AttributeDelta attrDelta : attributesDelta) {
+            LOG.info("attrDelta: {0}", attrDelta);
+            // add or remove members to/from role
+            if (attrDelta.getName().equalsIgnoreCase(ATTR_MEMBERS)) {
+                LOG.info("addMembersToRole");
+                addOrRemoveMember(uid, attrDelta, ROLE_ASSIGNMENT, options);
+            }
+        }
+
+    }
+
+
+    protected void addOrRemoveMember(Uid uid, AttributeDelta attrDelta, String path, OperationOptions options) {
+        LOG.info("addOrRemoveMember {0} , {1} , {2}", uid, attrDelta, path);
+        StringBuilder sbPath = new StringBuilder();
+        sbPath.append(path);
+        String roleDefinitionId = uid.getUidValue();
+
+        LOG.info("path: {0}", sbPath);
+
+        List<Object> removeValues = attrDelta.getValuesToRemove();
+        roleProcessRemove(sbPath, removeValues, roleDefinitionId, options);
+
+        List<Object> addValues = attrDelta.getValuesToAdd();
+        if (addValues != null && !addValues.isEmpty()) {
+            for (Object addValue : addValues) {
+                if (addValue != null) {
+
+                    JSONObject json = new JSONObject();
+                    String principalId = (String) addValue;
+                    String directoryScopeId = "/";
+
+                    json.put("principalId", principalId);
+                    json.put("directoryScopeId", directoryScopeId);
+                    json.put("roleDefinitionId", roleDefinitionId);
+
+                    LOG.ok("json: {0}", json.toString());
+                    postRequestNoContent(sbPath.toString(), json);
+                }
+            }
+        }
+    }
+
+    protected void addToRole(Uid uid, Set<Attribute> attributes) {
+        LOG.info("addToGroup {0} , {1}", uid, attributes);
+
+        for (Attribute attribute : attributes) {
+            if (attribute.getName().equalsIgnoreCase(ATTR_MEMBERS)) {
+                addMembersToRole(uid, attribute);
+            }
+        }
+    }
+
+    private void addMembersToRole(Uid uid, Attribute attribute) {
+        LOG.info("addMembersToRole {0} , {1}", uid, attribute);
+
+        StringBuilder sbPath = new StringBuilder();
+        sbPath.append(ROLE_ASSIGNMENT);
+        LOG.info("path: {0}", sbPath);
+
+        String roleDefinitionId = uid.getUidValue();
+
+        JSONObject json = new JSONObject();
+        String principalId = AttributeUtil.getAsStringValue(attribute);
+        String directoryScopeId = "/";
+
+        json.put("principalId", principalId);
+        json.put("directoryScopeId", directoryScopeId);
+        json.put("roleDefinitionId", roleDefinitionId);
+
+        LOG.ok("json: {0}", json.toString());
+        postRequestNoContent(sbPath.toString(), json);
+    }
+
+
+    protected void removeFromRole(Uid uid, Set<Attribute> attributes, OperationOptions options) {
+        LOG.info("removeFromRole {0}, {1}", uid, attributes);
+        for (Attribute attribute : attributes) {
+            if (attribute.getName().equalsIgnoreCase(ATTR_MEMBERS)) {
+                removeMemberFromRole(uid, attribute, options);
+            }
+        }
+    }
+
+    private void removeMemberFromRole(Uid uid, Attribute attribute, OperationOptions options) {
+        LOG.info("addOrRemoveMember {0} , {1} ", uid, attribute);
+        StringBuilder sbPath = new StringBuilder();
+        sbPath.append(ROLE_ASSIGNMENT);
+
+        String roleDefinitionId = uid.getUidValue();
+        String principalId = AttributeUtil.getAsStringValue(attribute);
+        String roleAssignmentId = getRoleAssignmentId(options, roleDefinitionId, principalId);
+        LOG.info("executeDeleteOperation principalId: {0} , sbPath.toString: {1} ", principalId, sbPath.toString());
+        executeDeleteOperation(roleAssignmentId, sbPath.toString());
+    }
+
+    private void postRequestNoContent(String path, JSONObject json) {
+        LOG.info("path: {0} , json {1}, ", path, json);
+        final GraphEndpoint endpoint = getGraphEndpoint();
+        final URIBuilder uriBuilder = endpoint.createURIBuilder().setPath(path);
+        final URI uri = endpoint.getUri(uriBuilder);
+        LOG.info("uri {0}", uri);
+
+
+        HttpEntityEnclosingRequestBase request;
+        LOG.info("HttpEntityEnclosingRequestBase request");
+
+        request = new HttpPost(uri);
+        LOG.info("create true - HTTP POST {0}", uri);
+        endpoint.callRequestNoContent(request, null, json);
+    }
+
+
+    private void roleProcessRemove(StringBuilder sbPath, List<Object> removeValues, String roleDefinitionId, OperationOptions options) {
+        if (removeValues != null && !removeValues.isEmpty()) {
+            for (Object removeValue : removeValues) {
+                if (removeValue != null) {
+
+                    String principalId = (String) removeValue;
+                    String roleAssignmentId = getRoleAssignmentId(options, roleDefinitionId, principalId);
+                    LOG.info("executeDeleteOperation principalId: {0} , sbPath.toString: {1} ", principalId, sbPath.toString());
+                    executeDeleteOperation(roleAssignmentId, sbPath.toString());
+                }
+            }
+        }
+    }
+
+    private void executeDeleteOperation(String roleAssignmentId, String path) {
+        LOG.info("Delete object of roleAssignment, id: {0}, Path: {1}", roleAssignmentId, path);
+
+        final GraphEndpoint endpoint = getGraphEndpoint();
+        final URIBuilder uriBuilder = endpoint.createURIBuilder();
+        uriBuilder.setPath(path + "/" + roleAssignmentId);
+
+        LOG.info("Uri for delete: {0}", uriBuilder);
+
+        final URI uri = endpoint.getUri(uriBuilder);
+        final HttpRequestBase request = new HttpDelete(uri);
+        endpoint.callRequest(request, false);
+    }
+
+
+    public void executeQueryForRole(Filter query, ResultsHandler handler, OperationOptions options) {
+        LOG.info("executeQueryForRole() Query: {0}", query);
+        final GraphEndpoint endpoint = getGraphEndpoint();
+
+        if (query instanceof EqualsFilter) {
+            final EqualsFilter equalsFilter = (EqualsFilter) query;
+            final String attributeName = equalsFilter.getAttribute().getName();
+            LOG.info("Query is instance of EqualsFilter: {0}", query);
+            if (equalsFilter.getAttribute() instanceof Uid) {
+                LOG.info("((EqualsFilter) query).getAttribute() instanceof Uid");
+
+                Uid uid = (Uid) ((EqualsFilter) query).getAttribute();
+                if (uid.getUidValue() == null) {
+                    invalidAttributeValue("Uid", query);
+                }
+                StringBuilder sbPath = new StringBuilder();
+                sbPath.append(ROLES).append("/").append(uid.getUidValue());
+
+                JSONObject roles = endpoint.executeGetRequest(sbPath.toString(), null, options, false);
+                handleJSONObject(options, roles, handler);
+            } else if (equalsFilter.getAttribute() instanceof Name) {
+                LOG.info("((EqualsFilter) query).getAttribute() instanceof Name");
+
+                Name name = (Name) ((EqualsFilter) query).getAttribute();
+                String nameValue = name.getNameValue();
+                if (nameValue == null) {
+                    invalidAttributeValue("Name", query);
+                }
+                final String customQuery = "$filter=" + ATTR_DISPLAY_NAME + " eq '" + nameValue + "'";
+                final JSONObject roles = endpoint.executeGetRequest(ROLES, customQuery, options, true);
+                handleJSONArray(options, roles, handler);
+            } else if (ATTR_DISPLAY_NAME.equals(attributeName)) {
+                final String attributeValue = getAttributeFirstValue(equalsFilter);
+                final String customQuery = "$filter=" + attributeName + " eq '" + attributeValue + "'";
+                final JSONObject roles = endpoint.executeGetRequest(ROLES, customQuery, options, true);
+                handleJSONArray(options, roles, handler);
+            }
+        } else if (query instanceof ContainsFilter) {
+            LOG.info("Query is instance of ContainsFilter: {0}", query);
+            final ContainsFilter containsFilter = (ContainsFilter) query;
+            final String attributeName = containsFilter.getAttribute().getName();
+            final String attributeValue = getAttributeFirstValue(containsFilter);
+            if (Arrays.asList(ATTR_DISPLAY_NAME).contains(attributeName)) {
+                String customQuery = "$filter=" + STARTSWITH + "(" + attributeName + ",'" + attributeValue + "')";
+                JSONObject roles = endpoint.executeGetRequest(ROLES, customQuery, options, true);
+                handleJSONArray(options, roles, handler);
+            }
+        } else if (query instanceof ContainsAllValuesFilter) {
+            LOG.info("[QUERY] - ContainsAllValuesFilter - query: {0}", query);
+            final ContainsAllValuesFilter containsAllValuesFilter = (ContainsAllValuesFilter) query;
+            final String attributeName = containsAllValuesFilter.getAttribute().getName();
+            final String attributeValue = getAttributeFirstValue(containsAllValuesFilter);
+            LOG.info("[QUERY] - ContainsAllValuesFilter - name is: {0} and value is: {1}", attributeName, attributeValue);
+
+            ArrayList<String> roleUIDs = saturateUserRoleMembership(options, attributeValue);
+            JSONObject groups = new JSONObject();
+            groups.put("value", new JSONArray());
+
+            LOG.info("[QUERY] - ContainsAllValuesFilter - roleUIDs: {0}", roleUIDs);
+
+            for (String roleUID : roleUIDs) {
+                String getPath = ROLES + "/" + roleUID;
+                JSONObject group = endpoint.executeGetRequest(getPath, null, options, false);
+                groups.append("value", group);
+            }
+
+            LOG.info("[QUERY] - ContainsAllValuesFilter - groups: {0}", groups);
+
+            handleJSONArray(options, groups, handler);
+        } else if (query == null) {
+            LOG.info("Query is null");
+            JSONObject roles = endpoint.executeGetRequest(ROLES, null, options, true);
+            handleJSONArray(options, roles, handler);
+        }
+    }
+
+    /**
+     * Query a role's members, add them to the group's JSON attributes (multivalue)
+     *
+     * @param options Operation options
+     * @param role Role to query for (JSON object resulting from previous API call)
+     *
+     * @return Original JSON, enriched with member information
+     */
+    private JSONObject saturateRoleMembership(OperationOptions options, JSONObject role) {
+        final GraphEndpoint endpoint = getGraphEndpoint();
+        final String uid = role.getString(ATTR_ID);
+
+        if (getSchemaTranslator().containsToGet(RoleProcessing.ROLE_NAME, options, ATTR_MEMBERS)) {
+            LOG.info("[GET] - saturateRoleMembership(), for role with UID: {0}", uid);
+
+            //get list of role members
+            final String customQuery = "$filter=roleDefinitionId eq '" + uid + "'";
+            final JSONObject roleMembers = endpoint.executeGetRequest(ROLE_ASSIGNMENT, customQuery, options, false);
+            role.put(ATTR_MEMBERS, getJSONArray(roleMembers, "principalId"));
+        }
+
+        return role;
+    }
+
+    private ArrayList<String> saturateUserRoleMembership(OperationOptions options, String principalId) {
+        final GraphEndpoint endpoint = getGraphEndpoint();
+
+        LOG.info("[GET] - saturateUsersRoleMembership(), for user with UID: {0}", principalId);
+
+        //get list of roles where the user is memberOf
+        final String customQuery = "$filter=principalId eq '" + principalId + "'";
+        final JSONObject roleMembers = endpoint.executeGetRequest(ROLE_ASSIGNMENT, customQuery, options, false);
+
+        LOG.info("[GET] - roleMembers: {0}", roleMembers);
+
+        return getArrayList(roleMembers, "roleDefinitionId");
+    }
+
+    private String getRoleAssignmentId(OperationOptions options, String roleDefinitionId, String principalId) {
+        final GraphEndpoint endpoint = getGraphEndpoint();
+
+        LOG.info("[GET] - getRoleAssignmentId(), for role with UID: {0}", roleDefinitionId);
+
+        //get exactly one roleAssignment by roleDefinitionId and principalId
+        final String customQuery = "$filter=roleDefinitionId eq '" + roleDefinitionId + "' and principalId eq '" + principalId + "'";
+        final JSONObject roleMembers = endpoint.executeGetRequest(ROLE_ASSIGNMENT, customQuery, options, false);
+
+        LOG.info("[GET] - roleMembers: {0}", roleMembers);
+
+        return (String) getIdFromAssignmentObject(roleMembers, "id", String.class);
+    }
+
+    @Override
+    protected boolean handleJSONObject(OperationOptions options, JSONObject role, ResultsHandler handler) {
+        LOG.info("processingRoleObjectFromGET (Object)");
+
+        if (!Boolean.TRUE.equals(options.getAllowPartialAttributeValues())) {
+            role = saturateRoleMembership(options, role);
+        }
+
+        final ConnectorObject connectorObject = convertRoleJSONObjectToConnectorObject(role).build();
+        LOG.info("processingRoleObjectFromGET, role: {0}, \n\tconnectorObject: {1}", role.get("id"), connectorObject.toString());
+        return handler.handle(connectorObject);
+    }
+
+    private ConnectorObjectBuilder convertRoleJSONObjectToConnectorObject(JSONObject role) {
+        LOG.info("convertRoleJSONObjectToConnectorObject");
+        ConnectorObjectBuilder builder = new ConnectorObjectBuilder();
+        builder.setObjectClass(RoleProcessing.ROLE);
+
+        // UID + NAME
+        getUIDIfExists(role, ATTR_ID, builder);
+        getNAMEIfExists(role, ATTR_DISPLAY_NAME, builder);
+
+        // single valued
+        getIfExists(role, ATTR_DESCRIPTION, String.class, builder);
+        getIfExists(role, ATTR_IS_BUILT_IN, Boolean.class, builder);
+        getIfExists(role, ATTR_IS_ENABLED, Boolean.class, builder);
+        getIfExists(role, ATTR_TEMPLATE_ID, String.class, builder);
+        getIfExists(role, ATTR_VERSION, String.class, builder);
+        getRoleInheritPermissionsIfExists(role, ATTR_INHERIT_PERMISSIONS_FROM_ODATA_CONTEXT, String.class, builder);
+
+        // specific item in the array
+        getRolePermissionsIfExists(role, ATTR_ROLE_PERMISSIONS, ATTR_ALLOWED_RESOURCE_ACTIONS, String.class, builder);
+        getFromArrayIfExists(role, ATTR_INHERIT_PERMISSIONS_FROM, ATTR_ID, String.class, builder);
+
+        // multivalued
+        getMultiIfExists(role, ATTR_RESOURCE_SCOPES, builder);
+        getMultiIfExists(role, ATTR_MEMBERS, builder);
+
+        return builder;
+    }
+
+
+}

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
@@ -18,10 +18,12 @@ public class SchemaTranslator {
         SchemaBuilder schemaBuilder = new SchemaBuilder(MSGraphConnector.class);
         UserProcessing userProcessing = new UserProcessing(graphEndpoint, this);
         GroupProcessing groupProcessing = new GroupProcessing(graphEndpoint);
+        RoleProcessing roleProcessing = new RoleProcessing(graphEndpoint);
         LicenseProcessing licenseProcessing = new LicenseProcessing(graphEndpoint, this);
 
         userProcessing.buildUserObjectClass(schemaBuilder);
         groupProcessing.buildGroupObjectClass(schemaBuilder);
+        roleProcessing.buildRoleObjectClass(schemaBuilder);
         licenseProcessing.buildLicenseObjectClass(schemaBuilder);
 
         schemaBuilder.defineOperationOption(OperationOptionInfoBuilder.buildAttributesToGet(), SearchOp.class);

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessingTest.java
@@ -12,10 +12,10 @@ import java.io.InputStream;
 import java.util.List;
 
 /**
- * Test case for {@link GroupProcessing}
+ * Test case for {@link RoleProcessing}
  */
 @Test(groups = "unit")
-public class GroupProcessingTest extends BasicConfigurationForTests {
+public class RoleProcessingTest extends BasicConfigurationForTests {
 
     private JSONObject parseResource(String fileName) throws IOException  {
         try (InputStream is = getClass().getResourceAsStream(fileName)) {
@@ -23,12 +23,12 @@ public class GroupProcessingTest extends BasicConfigurationForTests {
         }
     }
 
-    final GroupProcessing groupProcessing = new GroupProcessing(new GraphEndpoint(getConfiguration()));
+    final RoleProcessing roleProcessing = new RoleProcessing(new GraphEndpoint(getConfiguration()));
 
     @Test
     public void testParseGroupMembers() throws Exception {
         final JSONObject membersJson = parseResource("groupMembers.json");
-        final JSONArray jarr = groupProcessing.getJSONArray(membersJson, "id");
+        final JSONArray jarr = roleProcessing.getJSONArray(membersJson, "id");
         final List<Object> ids = jarr.toList();
         Assert.assertEquals(2, ids.size());
         Assert.assertEquals("9639bcbc-0089-4855-a793-44b940e52286", ids.get(0));

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/common/ObjectConstants.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/common/ObjectConstants.java
@@ -98,19 +98,35 @@ public interface ObjectConstants {
     String ATTR_ICF_ENABLED = "__ENABLE__";
 
 
+    // Role/Group common
+    String ATTR_DESCRIPTION = "description";
+    String ATTR_MEMBERS = "members";
     // Group
 
     String ATTR_ALLOWEXTERNALSENDERS = "allowExternalSenders";
     String ATTR_AUTOSUBSCRIBENEWMEMBERS = "autoSubscribeNewMembers";
     String ATTR_CLASSIFICATION = "classification";
     String ATTR_CREATEDDATETIME = "createdDateTime";
-    String ATTR_DESCRIPTION = "description";
     String ATTR_GROUPTYPES = "groupTypes";
     String ATTR_ISSUBSCRIBEDBYMAIL = "isSubscribedByMail";
     String ATTR_MAILENABLED = "mailEnabled";
     String ATTR_SECURITYENABLED = "securityEnabled";
     String ATTR_UNSEENCOUNT = "unseenCount";
     String ATTR_VISIBILITY = "visibility";
-    String ATTR_MEMBERS = "members";
     String ATTR_OWNERS = "owners";
+    
+    // Role
+    
+    String ATTR_IS_BUILT_IN = "isBuiltIn";
+    String ATTR_IS_ENABLED = "isEnabled";
+    String ATTR_RESOURCE_SCOPES = "resourceScopes";
+    String ATTR_TEMPLATE_ID = "templateId";
+    String ATTR_VERSION = "version";
+    String ATTR_ROLE_PERMISSIONS = "rolePermissions";
+    String ATTR_ALLOWED_RESOURCE_ACTIONS = "allowedResourceActions";
+    String ATTR_ROLE_PERMISSIONS_ALL = ATTR_ROLE_PERMISSIONS + "." + ATTR_ALLOWED_RESOURCE_ACTIONS;
+    String ATTR_INHERIT_PERMISSIONS_FROM_ODATA_CONTEXT = "inheritsPermissionsFrom@odata.context";
+    String ATTR_INHERIT_PERMISSIONS_FROM = "inheritsPermissionsFrom";
+    String ATTR_INHERIT_PERMISSIONS_FROM_ALL = ATTR_INHERIT_PERMISSIONS_FROM + "." + ATTR_ID;
+
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/CreateActionTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/CreateActionTest.java
@@ -1,23 +1,16 @@
 package com.evolveum.polygon.connector.msgraphapi.integration;
 
-import com.evolveum.polygon.connector.msgraphapi.MSGraphConfiguration;
-import com.evolveum.polygon.connector.msgraphapi.MSGraphConnector;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.AlreadyExistsException;
 import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
 import org.identityconnectors.framework.common.exceptions.InvalidPasswordException;
 import org.identityconnectors.framework.common.objects.*;
-import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
-import org.identityconnectors.framework.common.objects.filter.FilterBuilder;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 
 public class CreateActionTest extends BasicConfigurationForTests {

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/FilteringTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/FilteringTest.java
@@ -1,6 +1,7 @@
 package com.evolveum.polygon.connector.msgraphapi.integration;
 
 import com.evolveum.polygon.connector.msgraphapi.MSGraphConnector;
+import static com.evolveum.polygon.connector.msgraphapi.RoleProcessing.ROLE_NAME;
 import com.evolveum.polygon.connector.msgraphapi.common.TestSearchResultsHandler;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
@@ -253,5 +254,26 @@ public class FilteringTest extends BasicConfigurationForTests {
         deleteWaitAndRetry(objectClassGroup, groupBlue, options);
         deleteWaitAndRetry(objectClassGroup, groupYellow, options);
     }
+    
+    @Test(priority = 22)
+    public void filteringRoleObjectClass() throws Exception {
 
+        msGraphConnector = new MSGraphConnector();
+        msGraphConfiguration = getConfiguration();
+        msGraphConnector.init(msGraphConfiguration);
+
+        OperationOptions options = getDefaultRoleOperationOptions();
+
+        ObjectClass objectClassRole = new ObjectClass(ROLE_NAME);
+
+        AttributeFilter containsFilterRole;
+        containsFilterRole = (ContainsFilter) FilterBuilder.contains(AttributeBuilder.build("displayName", roleWhichExistsInTenantDisplayName));
+
+        TestSearchResultsHandler handlerRole = getResultHandler();
+        
+        msGraphConnector.executeQuery(objectClassRole, containsFilterRole, handlerRole, options);
+        
+        ArrayList<ConnectorObject> resultsRole = handlerRole.getResult();
+        Assert.assertTrue(!resultsRole.isEmpty());
+    }
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/ListAllTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/ListAllTest.java
@@ -1,11 +1,9 @@
 package com.evolveum.polygon.connector.msgraphapi.integration;
 
-import com.evolveum.polygon.connector.msgraphapi.MSGraphConfiguration;
 import com.evolveum.polygon.connector.msgraphapi.MSGraphConnector;
+import static com.evolveum.polygon.connector.msgraphapi.RoleProcessing.ROLE_NAME;
 import com.evolveum.polygon.connector.msgraphapi.common.TestSearchResultsHandler;
-import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
 import org.identityconnectors.framework.common.objects.*;
-import org.identityconnectors.framework.spi.SearchResultsHandler;
 import org.junit.Assert;
 import org.testng.annotations.Test;
 
@@ -45,6 +43,31 @@ public class ListAllTest extends BasicConfigurationForTests {
         resultsGroup = handlerGroup.getResult();
         deleteWaitAndRetry(ObjectClass.GROUP, groupBlue, options);
         Assert.assertTrue(!resultsGroup.isEmpty());
+
+    }
+    
+    @Test(priority = 22)
+    public void filteringEmptyPageTestRoleObjectClass() throws Exception {
+        msGraphConnector = new MSGraphConnector();
+
+        msGraphConfiguration = getConfiguration();
+        msGraphConnector.init(msGraphConfiguration);
+        OperationOptions options = new OperationOptions(new HashMap<>());
+        ObjectClass objectClass = new ObjectClass(ROLE_NAME);
+
+        Map<String, Object> operationOptions = new HashMap<>();
+        operationOptions.put("ALLOW_PARTIAL_ATTRIBUTE_VALUES", true);
+        operationOptions.put(OperationOptions.OP_PAGED_RESULTS_OFFSET, 900);
+        operationOptions.put(OperationOptions.OP_PAGE_SIZE, 100);
+        options = new OperationOptions(operationOptions);
+
+        ArrayList<ConnectorObject> resultsRoles = new ArrayList<>();
+        TestSearchResultsHandler handlerRole = new TestSearchResultsHandler();
+
+        msGraphConnector.executeQuery(objectClass, null, handlerRole, options);
+
+        resultsRoles = handlerRole.getResult();
+        Assert.assertTrue(!resultsRoles.isEmpty());
 
     }
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/PropertiesParser.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/PropertiesParser.java
@@ -24,6 +24,7 @@ public class PropertiesParser {
     private static final String LICENSES = "licenses";
     private static final String LICENSES2 = "licenses2";
     private static final String DISABLED_PLANS = "disabledPlans";
+    private static final String EXISTED_ROLE_DISPLAY_NAME = "existedRoleDisplayName";
 
     public PropertiesParser() {
 
@@ -37,7 +38,6 @@ public class PropertiesParser {
             LOGGER.error(e, "Properties file not found", e.getLocalizedMessage());
         }
     }
-
 
     public String getClientId() {
         return (String) PROPERTIES.get(CLIENT_ID);
@@ -73,5 +73,9 @@ public class PropertiesParser {
             return new String[]{(String) PROPERTIES.get(DISABLED_PLANS)};
         else
             return new String[0];
+    }
+    
+    public String getExistedRoleDisplayName() {
+      return (String) PROPERTIES.get(EXISTED_ROLE_DISPLAY_NAME);
     }
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/RoleMembershipManagementTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/RoleMembershipManagementTest.java
@@ -1,0 +1,200 @@
+package com.evolveum.polygon.connector.msgraphapi.integration;
+
+import static com.evolveum.polygon.connector.msgraphapi.RoleProcessing.ROLE_NAME;
+import com.evolveum.polygon.connector.msgraphapi.common.TestSearchResultsHandler;
+import static com.evolveum.polygon.connector.msgraphapi.integration.BasicConfigurationForTests._REPEAT_COUNT;
+import static com.evolveum.polygon.connector.msgraphapi.integration.BasicConfigurationForTests._REPEAT_INTERVAL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import org.identityconnectors.common.security.GuardedString;
+import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
+import org.identityconnectors.framework.common.exceptions.UnknownUidException;
+import org.identityconnectors.framework.common.objects.Attribute;
+import org.identityconnectors.framework.common.objects.AttributeBuilder;
+import org.identityconnectors.framework.common.objects.ConnectorObject;
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.OperationOptions;
+import org.identityconnectors.framework.common.objects.Uid;
+import org.identityconnectors.framework.common.objects.filter.AttributeFilter;
+import org.identityconnectors.framework.common.objects.filter.ContainsFilter;
+import org.identityconnectors.framework.common.objects.filter.FilterBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author jan.mokracek
+ */
+public class RoleMembershipManagementTest extends BasicConfigurationForTests {
+
+    private Uid roleTestUser;
+    private Uid roleTestUser1;
+    private Uid roleTestUser2;
+
+    @Test(priority = 10)
+    public void createUserAndAddUserToAlreadyExistedRoleInTenant() throws Exception {
+        msGraphConfiguration = getConfiguration();
+        msGraphConnector.init(msGraphConfiguration);
+
+        OperationOptions options = new OperationOptions(new HashMap<>());
+        ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
+
+        Set<Attribute> attributesAccount = new HashSet<>();
+        attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
+        attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
+        attributesAccount.add(AttributeBuilder.build("displayName", "Yellow221122232457"));
+        attributesAccount.add(AttributeBuilder.build("mail", "Yellow22112223457@example.com"));
+        attributesAccount.add(AttributeBuilder.build("mailNickname", "Yellow22112223457"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Yellow22112223457@" + tenantId));
+        GuardedString pass = new GuardedString("HelloPassword99".toCharArray());
+        attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
+
+        roleTestUser = msGraphConnector.create(objectClassAccount, attributesAccount, options);
+        ConnectorObject role = getAlreadyExistedRoleInTenant();
+
+        addUserToRole(roleTestUser, role);
+
+        Assert.assertTrue(isUserMemberOfRoleWaitAndRetry(roleTestUser, true));
+    }
+
+    @Test(priority = 20)
+    public void createUserAndCheckNonExistentRoleMembership() throws Exception {
+        msGraphConfiguration = getConfiguration();
+        msGraphConnector.init(msGraphConfiguration);
+
+        OperationOptions options = new OperationOptions(new HashMap<>());
+        ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
+
+        Set<Attribute> attributesAccount = new HashSet<>();
+        attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
+        attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
+        attributesAccount.add(AttributeBuilder.build("displayName", "Yellow88"));
+        attributesAccount.add(AttributeBuilder.build("mail", "Yellow88@example.com"));
+        attributesAccount.add(AttributeBuilder.build("mailNickname", "Yellow88"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Yellow88@" + tenantId));
+        GuardedString pass = new GuardedString("HelloPassword99".toCharArray());
+        attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
+
+        roleTestUser1 = msGraphConnector.create(objectClassAccount, attributesAccount, options);
+
+        Assert.assertTrue(!isUserMemberOfRoleWaitAndRetry(roleTestUser1, false));
+    }
+
+    @Test(priority = 30)
+    public void createUserRemoveRoleMembership() throws Exception {
+        msGraphConfiguration = getConfiguration();
+        msGraphConnector.init(msGraphConfiguration);
+
+        OperationOptions options = new OperationOptions(new HashMap<>());
+
+        ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
+
+        Set<Attribute> attributesAccount = new HashSet<>();
+        attributesAccount.add(AttributeBuilder.build("accountEnabled", true));
+        attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
+        attributesAccount.add(AttributeBuilder.build("displayName", "Yellow182822222211222212111"));
+        attributesAccount.add(AttributeBuilder.build("mail", "Yellow8811221222221122222112@example.com"));
+        attributesAccount.add(AttributeBuilder.build("mailNickname", "Yellow812212222228122221111"));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", "Yellow128212222281222122111@" + tenantId));
+        GuardedString pass = new GuardedString("HelloPassword99".toCharArray());
+        attributesAccount.add(AttributeBuilder.build("__PASSWORD__", pass));
+
+        roleTestUser2 = msGraphConnector.create(objectClassAccount, attributesAccount, options);
+        ConnectorObject role = getAlreadyExistedRoleInTenant();
+
+        addUserToRole(roleTestUser2, role);
+
+        if (isUserMemberOfRoleWaitAndRetry(roleTestUser2, true)) {
+            removeUserFromRole(roleTestUser2, role);
+            Assert.assertFalse(isUserMemberOfRoleWaitAndRetry(roleTestUser2, false));
+        } else {
+            Assert.fail("User wasn't added to the role.");
+        }
+    }
+
+    private ConnectorObject getAlreadyExistedRoleInTenant() {
+        OperationOptions options = getDefaultRoleOperationOptions();
+
+        ObjectClass objectClassRole = new ObjectClass(ROLE_NAME);
+
+        AttributeFilter containsFilterRole;
+        containsFilterRole = (ContainsFilter) FilterBuilder.contains(AttributeBuilder.build("displayName", roleWhichExistsInTenantDisplayName));
+        TestSearchResultsHandler handlerRole = getResultHandler();
+        msGraphConnector.executeQuery(objectClassRole, containsFilterRole, handlerRole, options);
+        ArrayList<ConnectorObject> resultsRole = handlerRole.getResult();
+
+        if (resultsRole.size() != 1) {
+            Assert.fail("Chosen role displayName is not unique or doesn't even exists");
+        }
+
+        return resultsRole.get(0);
+    }
+
+    private void removeUserFromRole(Uid userUid, ConnectorObject role) throws Exception {
+        ObjectClass objectClassRole = new ObjectClass(ROLE_NAME);
+        OperationOptions options = new OperationOptions(new HashMap<>());
+
+        Set<Attribute> removeUserUid = new HashSet<>();
+        AttributeBuilder attr = new AttributeBuilder();
+        attr.setName(ATTR_MEMBERS);
+        attr.addValue(userUid.getUidValue());
+        removeUserUid.add(attr.build());
+        int iterator = 0;
+        while (_REPEAT_COUNT > iterator) {
+            try {
+                role = getAlreadyExistedRoleInTenant();
+                removeAttributeWaitAndRetry(objectClassRole, role.getUid(), removeUserUid, options);
+                break;
+            } catch (InvalidAttributeValueException e) {
+                Thread.sleep(_REPEAT_INTERVAL);
+            }
+            iterator++;
+        }
+    }
+
+    private void addUserToRole(Uid userUid, ConnectorObject role) throws Exception {
+        ObjectClass objectClassRole = new ObjectClass(ROLE_NAME);
+        OperationOptions options = new OperationOptions(new HashMap<>());
+
+        Set<Attribute> addedUserUid = new HashSet<>();
+        AttributeBuilder attr = new AttributeBuilder();
+        attr.setName(ATTR_MEMBERS);
+        attr.addValue(userUid.getUidValue());
+        addedUserUid.add(attr.build());
+        addAttributeWaitAndRetry(objectClassRole, role.getUid(), addedUserUid, options);
+    }
+
+    protected boolean isUserMemberOfRoleWaitAndRetry(Uid userUid, boolean userShouldBeAMember) throws InterruptedException {
+        boolean isUserMemberOfRole = false;
+        int iterator = 0;
+        while (_REPEAT_COUNT > iterator) {
+            ConnectorObject role = null;
+            try {
+                role = getAlreadyExistedRoleInTenant();
+            } catch (UnknownUidException e) {
+
+            }
+            isUserMemberOfRole = role.getAttributeByName(ATTR_MEMBERS).getValue().contains(userUid.getUidValue());
+            if (isUserMemberOfRole != userShouldBeAMember) {
+                Thread.sleep(_REPEAT_INTERVAL);
+            } else {
+                break;
+            }
+            iterator++;
+        }
+        return isUserMemberOfRole;
+    }
+
+    @Test(priority = 40)
+    public void DeleteUserTest() {
+        ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
+        OperationOptions options = new OperationOptions(new HashMap<>());
+
+        msGraphConnector.delete(objectClassAccount, roleTestUser, options);
+        msGraphConnector.delete(objectClassAccount, roleTestUser1, options);
+        msGraphConnector.delete(objectClassAccount, roleTestUser2, options);
+        msGraphConnector.dispose();
+    }
+}

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/UpdateTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/UpdateTest.java
@@ -1,6 +1,5 @@
 package com.evolveum.polygon.connector.msgraphapi.integration;
 
-import com.evolveum.polygon.connector.msgraphapi.MSGraphConfiguration;
 import com.evolveum.polygon.connector.msgraphapi.MSGraphConnector;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.UnknownUidException;

--- a/src/test/resources/testProperties/propertiesForTest.properties
+++ b/src/test/resources/testProperties/propertiesForTest.properties
@@ -4,6 +4,8 @@ clientSecret=
 #e.g. clientSecret=aaaaa~aaaaabbbbbcccccdd~eeeeeeeeeeeee
 tenantID=
 #e.g. tenantID=example.onmicrosoft.com
+existedRoleDisplayName=
+#e.g. existedRoleDisplayName=Global Reader, choose a role where you don't mind assigning/removing members
 
 # optional for license assignment integration testing
 #licenses=SKUID1[,SKUID2...]


### PR DESCRIPTION
- Added role membership management (assign/unassign roles) to user - designed for Czech Post
- Role management as such (create/delete) is not supported by the connector. Only "members" attribute is updated.
- Added additional permissions to README.md that are required to manage role membership.
- Added required tests for role membership management. New tests are heavily time based because of slow cloud synchronization. That's why the performing of tests is so slow and there are lot of do while loops with sleep construction in the source code.
- Unused imports in test packages were optimized.
- Original code of the new feature was designed by @frantiekm.
- New tests were created by me.