### PR TITLE
Fix NPE when options is empty

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -7,8 +7,6 @@ import org.identityconnectors.common.CollectionUtil;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
 import org.identityconnectors.framework.common.objects.*;
-import org.identityconnectors.framework.common.objects.filter.ContainsFilter;
-import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -908,7 +906,8 @@ public class UserProcessing extends ObjectProcessing {
                 StringBuilder sbPath = new StringBuilder();
                 sbPath.append(toGetURLByUserPrincipalName(translatedQuery)).append("/");
                 String filter = "";
-                if (shouldReturnAttribute(options).contains(ATTR_MANAGER_ID)){
+                Set<String> attributesToGet = getAttributesToGet(options);
+                if (attributesToGet.contains(ATTR_MANAGER_ID)){
 
                     LOG.info("Fetching manager info for account: {0}", translatedQuery);
 
@@ -923,7 +922,7 @@ public class UserProcessing extends ObjectProcessing {
                 JSONObject user = endpoint.executeGetRequest(sbPath.toString(), selectorSingle + "&" +
                         filter, options, false);
 
-                if (shouldReturnAttribute(options).contains(ATTR_SIGN_IN)) {
+                if (attributesToGet.contains(ATTR_SIGN_IN)) {
                     LOG.info("Fetching sing-in info for account: {0}", translatedQuery);
                     sbPath = new StringBuilder()
                             .append("/auditLogs/signIns");
@@ -977,22 +976,12 @@ public class UserProcessing extends ObjectProcessing {
         }
     }
 
-    private ArrayList<String> shouldReturnAttribute(OperationOptions options) {
-        if (options == null) {
-
-            return null;
+    protected Set<String> getAttributesToGet(OperationOptions options) {
+        if (options == null || options.getAttributesToGet() == null) {
+            return Collections.emptySet();
         }
-
-        ArrayList<String> attrNameArray = new ArrayList<String>(Arrays.asList(options.getAttributesToGet()));
-
-        if (attrNameArray == null || attrNameArray.isEmpty()) {
-
-            return null;
-        }
-
-        return attrNameArray;
+        return new HashSet<>(Arrays.asList(options.getAttributesToGet()));
     }
-
 
     /**
      * When the userPrincipalName begins with a $ character, remove the slash (/) after /users and

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/UserProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/UserProcessingTest.java
@@ -1,0 +1,28 @@
+package com.evolveum.polygon.connector.msgraphapi;
+
+import com.evolveum.polygon.connector.msgraphapi.integration.BasicConfigurationForTests;
+import org.identityconnectors.framework.common.objects.OperationOptions;
+import org.identityconnectors.framework.common.objects.OperationOptionsBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test case for {@link UserProcessing}
+ */
+@Test(groups = "unit")
+public class UserProcessingTest extends BasicConfigurationForTests {
+
+    @Test
+    public void testGetAttributesToGet() throws Exception {
+        UserProcessing userProcessing = new UserProcessing(null, null);
+        Assert.assertNotNull(userProcessing.getAttributesToGet(null));
+
+        OperationOptions emptyOptions = new OperationOptionsBuilder().build();
+        Assert.assertNotNull(userProcessing.getAttributesToGet(emptyOptions));
+
+        OperationOptions options = new OperationOptionsBuilder().setAttributesToGet("manager").build();
+
+        Assert.assertTrue(userProcessing.getAttributesToGet(options).contains("manager"));
+        Assert.assertFalse(userProcessing.getAttributesToGet(options).contains("signIn"));
+    }
+}


### PR DESCRIPTION
I got NPE when no `<fetchStrategy>` in the resource configuration.

```
midpoint_1            | 2023-04-06 15:14:33,759 [] [pool-5-thread-9] WARN (com.evolveum.midpoint.provisioning.ucf.impl.connid.ConnIdUtil): Got ConnId exception (might be handled by upper layers later) java.lang.NullPointerException in connector:1285b4d8-3d35-45e4-a5d1-685fe9c71308(ConnId com.evolveum.polygon.connector.msgraphapi.MSGraphConnector v1.0.2.1): ConnectorSpec.Main(resource:10000000-0000-0000-0000-000000000004(Azure AD)) while getting object identified by ConnId UID 'b8bd77a6-071d-428d-a8c4-3334bb3bd6a1': null, reason: null (class java.lang.NullPointerException)
midpoint_1            | 2023-04-06 15:14:33,759 [MODEL] [pool-5-thread-9] ERROR (com.evolveum.midpoint.model.impl.lens.ChangeExecutor): Error executing changes for (account (coopAccount) on resource:10000000-0000-0000-0000-000000000004(Azure AD)): null
midpoint_1            | java.lang.NullPointerException: null
midpoint_1            |         at java.base/java.util.Objects.requireNonNull(Objects.java:208)
midpoint_1            |         at java.base/java.util.Arrays$ArrayList.<init>(Arrays.java:4137)
midpoint_1            |         at java.base/java.util.Arrays.asList(Arrays.java:4122)
midpoint_1            |         at com.evolveum.polygon.connector.msgraphapi.UserProcessing.shouldReturnAttribute(UserProcessing.java:986)
midpoint_1            |         at com.evolveum.polygon.connector.msgraphapi.UserProcessing.executeQueryForUser(UserProcessing.java:911)
midpoint_1            |         at com.evolveum.polygon.connector.msgraphapi.MSGraphConnector.executeQuery(MSGraphConnector.java:376)
midpoint_1            |         at com.evolveum.polygon.connector.msgraphapi.MSGraphConnector.executeQuery(MSGraphConnector.java:40)
midpoint_1            |         at org.identityconnectors.framework.impl.api.local.operations.SearchImpl.rawSearch(SearchImpl.java:197)
midpoint_1            |         at org.identityconnectors.framework.impl.api.local.operations.SearchImpl.search(SearchImpl.java:133)
midpoint_1            |         at jdk.internal.reflect.GeneratedMethodAccessor535.invoke(Unknown Source)
midpoint_1            |         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
midpoint_1            |         at java.base/java.lang.reflect.Method.invoke(Method.java:568)
midpoint_1            |         at org.identityconnectors.framework.impl.api.local.operations.ConnectorAPIOperationRunnerProxy.invoke(ConnectorAPIOperationRunnerProxy.java:99)
midpoint_1            |         at jdk.proxy2/jdk.proxy2.$Proxy148.search(Unknown Source)
midpoint_1            |         at org.identityconnectors.framework.impl.api.local.operations.GetImpl.getObject(GetImpl.java:67)
midpoint_1            |         at jdk.internal.reflect.GeneratedMethodAccessor539.invoke(Unknown Source)
midpoint_1            |         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
midpoint_1            |         at java.base/java.lang.reflect.Method.invoke(Method.java:568)
midpoint_1            |         at org.identityconnectors.framework.impl.api.local.operations.ThreadClassLoaderManagerProxy.invoke(ThreadClassLoaderManagerProxy.java:96)
midpoint_1            |         at jdk.proxy2/jdk.proxy2.$Proxy149.getObject(Unknown Source)
midpoint_1            |         at jdk.internal.reflect.GeneratedMethodAccessor539.invoke(Unknown Source)
midpoint_1            |         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
midpoint_1            |         at java.base/java.lang.reflect.Method.invoke(Method.java:568)
midpoint_1            |         at org.identityconnectors.framework.impl.api.DelegatingTimeoutProxy.invoke(DelegatingTimeoutProxy.java:99)
midpoint_1            |         at jdk.proxy2/jdk.proxy2.$Proxy149.getObject(Unknown Source)
midpoint_1            |         at jdk.internal.reflect.GeneratedMethodAccessor539.invoke(Unknown Source)
midpoint_1            |         at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
midpoint_1            |         at java.base/java.lang.reflect.Method.invoke(Method.java:568)
midpoint_1            |         at org.identityconnectors.framework.impl.api.LoggingProxy.invoke(LoggingProxy.java:89)
midpoint_1            |         at jdk.proxy2/jdk.proxy2.$Proxy149.getObject(Unknown Source)
midpoint_1            |         at org.identityconnectors.framework.impl.api.AbstractConnectorFacade.getObject(AbstractConnectorFacade.java:254)
midpoint_1            |         at com.evolveum.midpoint.provisioning.ucf.impl.connid.ConnectorInstanceConnIdImpl.fetchConnectorObject(ConnectorInstanceConnIdImpl.java:571)
midpoint_1            |         at com.evolveum.midpoint.provisioning.ucf.impl.connid.ConnectorInstanceConnIdImpl.fetchObject(ConnectorInstanceConnIdImpl.java:505)
midpoint_1            |         at com.evolveum.midpoint.provisioning.impl.resourceobjects.ResourceObjectReferenceResolver.fetchResourceObject(ResourceObjectReferenceResolver.java:205)
midpoint_1            |         at com.evolveum.midpoint.provisioning.impl.resourceobjects.ResourceObjectConverter.fetchResourceObject(ResourceObjectConverter.java:1477)
midpoint_1            |         at com.evolveum.midpoint.provisioning.impl.resourceobjects.ResourceObjectConverter.preReadShadow(ResourceObjectConverter.java:893)
midpoint_1            |         at com.evolveum.midpoint.provisioning.impl.resourceobjects.ResourceObjectConverter.modifyResourceObject(ResourceObjectConverter.java:566)
midpoint_1            |         at com.evolveum.midpoint.provisioning.impl.shadows.ModifyHelper.modifyShadowAttempt(ModifyHelper.java:198)
midpoint_1            |         at com.evolveum.midpoint.provisioning.impl.shadows.ModifyHelper.modifyShadow(ModifyHelper.java:124)
midpoint_1            |         at com.evolveum.midpoint.provisioning.impl.shadows.ShadowsFacade.modifyShadow(ShadowsFacade.java:88)
midpoint_1            |         at com.evolveum.midpoint.provisioning.impl.ProvisioningServiceImpl.modifyObject(ProvisioningServiceImpl.java:606)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.executor.DeltaExecution.modifyProvisioningObject(DeltaExecution.java:606)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.executor.DeltaExecution.executeModification(DeltaExecution.java:551)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.executor.DeltaExecution.execute(DeltaExecution.java:166)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.executor.ProjectionChangeExecution.execute(ProjectionChangeExecution.java:129)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.ChangeExecutor.executeProjectionsChanges(ChangeExecutor.java:98)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.ChangeExecutor.executeChanges(ChangeExecutor.java:61)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.ClockworkClick.lambda$processSecondary$0(ClockworkClick.java:230)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.ClockworkMedic.partialExecute(ClockworkMedic.java:343)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.ClockworkClick.processSecondary(ClockworkClick.java:228)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.ClockworkClick.moveStateForward(ClockworkClick.java:195)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.ClockworkClick.click(ClockworkClick.java:119)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.Clockwork.click(Clockwork.java:382)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.Clockwork.runWithConflictDetection(Clockwork.java:150)
midpoint_1            |         at com.evolveum.midpoint.model.impl.lens.Clockwork.run(Clockwork.java:104)
midpoint_1            |         at com.evolveum.midpoint.model.impl.controller.ModelController.executeChangesNonRaw(ModelController.java:438)
midpoint_1            |         at com.evolveum.midpoint.model.impl.controller.ModelController.executeChanges(ModelController.java:399)
midpoint_1            |         at com.evolveum.midpoint.gui.impl.page.admin.ProgressAwareChangesExecutorImpl$1.callWithContextPrepared(ProgressAwareChangesExecutorImpl.java:150)
midpoint_1            |         at com.evolveum.midpoint.gui.impl.page.admin.ProgressAwareChangesExecutorImpl$1.callWithContextPrepared(ProgressAwareChangesExecutorImpl.java:135)
midpoint_1            |         at com.evolveum.midpoint.web.component.SecurityContextAwareCallable.call(SecurityContextAwareCallable.java:50)
midpoint_1            |         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
midpoint_1            |         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
midpoint_1            |         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
midpoint_1            |         at java.base/java.lang.Thread.run(Thread.java:833)
```