### PR TITLE
Group Processing and Filtering Improvements

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
@@ -446,7 +446,7 @@ public class GroupProcessing extends ObjectProcessing {
 
             } else {
                 if (translatedQuery.hasIdOrMembershipExpression()) {
-
+                    query = translatedQuery.getIdOrMembershipExpression();
                 } else {
 
                     fetchAll = true;

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/util/FilterHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/util/FilterHandler.java
@@ -670,7 +670,8 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
     }
 
     private String wrapValue(String s) {
-
+        // Escape single quote
+        s = s.replace("'", "''");
         s = _VALUE_WRAPPER + s + _VALUE_WRAPPER;
 
         return s;
@@ -810,7 +811,8 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             query.append(name);
             query.append(":");
-            query.append(singleValue);
+            // Escape double quote
+            query.append(singleValue.replace("\"", "\\\""));
 
         }
 


### PR DESCRIPTION
I have made the following improvements:

## Fixed inability to fetch a group
Unfortunately, the following commit caused degrade to fail to fetch a group because `query` is null.

https://github.com/Evolveum/connector-microsoft-graph-api/commit/41e8fa67b7d881c1345ca8747c4d1b112be21494#diff-2e30a2a5362eadaebf8f9ece737870a368ad95c0f54274ab333d50d268613ec6R448-R449

## Fixed filter escaping
I fixed escaping omissions in the following cases:

- Single quotes need escaping in $filter if value contains single quotes
- Double quotes need escaping in $search if value contains double quotes

## Fixed to prevent duplicate Groups being created
For historical reason, Groups are allowed to duplicate displayName
(Reference: https://morgansimonsen.com/2016/06/28/azure-ad-allows-duplicate-group-names/).

However, Microsoft strives to avoid group created with duplicated names. For example, duplicate Group creation from the UI will result in an error.
Unfortunately, Microsoft Graph v1.0 does not perform duplicate name checking, so we have to implement in this connector side.

Note: As Group creation is eventual consistency, the existence check here does not work well for freshly created Groups and will result in the creation of duplicate Groups. This is unavoidable due to the system design of Azure AD.
(Reference: https://github.com/MicrosoftDocs/azure-docs/issues/94121#issuecomment-1191792188)