### PR TITLE
Improved query processing, unnecessary string conversion in logging and typo

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GraphEndpoint.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GraphEndpoint.java
@@ -116,7 +116,7 @@ public class GraphEndpoint {
 
             if (configuration.hasProxy()) {
 
-                LOG.info("Authenticating through proxy[{0}]", configuration.getProxyAddress().toString());
+                LOG.info("Authenticating through proxy[{0}]", configuration.getProxyAddress());
                 context.setProxy(createProxy());
             }
             Future<AuthenticationResult> future;
@@ -161,8 +161,7 @@ public class GraphEndpoint {
 
             throw new ConnectionFailedException("Exception while authenticating to the service provider: "+ e.getLocalizedMessage());
         } catch (IOException e) {
-
-            LOG.error(e.toString());
+            LOG.error(e, e.toString());
         } finally {
             service.shutdown();
         }
@@ -237,7 +236,7 @@ public class GraphEndpoint {
             }
         });
         if (configuration.hasProxy()) {
-            LOG.info("Executing request through proxy[{0}]", configuration.getProxyAddress().toString());
+            LOG.info("Executing request through proxy[{0}]", configuration.getProxyAddress());
             clientBuilder.setProxy(
                     new HttpHost(configuration.getProxyAddress().getAddress(), configuration.getProxyAddress().getPort())
             );
@@ -331,7 +330,7 @@ public class GraphEndpoint {
         request.setHeader("Authorization", getAccessToken().getAccessToken());
         request.setHeader("Content-Type", "application/json");
         request.setHeader("ConsistencyLevel", "eventual");
-        LOG.ok("Request execution -> HtttpUriRequest: {0}", request);
+        LOG.ok("Request execution -> HttpUriRequest: {0}", request);
         CloseableHttpResponse response;
         int retryCount = 0;
         try {
@@ -465,12 +464,15 @@ public class GraphEndpoint {
         LOG.ok("callRequest execution");
         String result = null;
         request.setHeader("ConsistencyLevel", "eventual");
-        LOG.ok("URL in request: {0}", request.getRequestLine().getUri());
-        LOG.ok("Enumerating headers");
-        List<Header> httpHeaders = Arrays.asList(request.getAllHeaders());
-        for (Header header : httpHeaders) {
-            LOG.info("Headers.. name,value:" + header.getName() + "," + header.getValue());
+
+        if (LOG.isOk()) {
+            LOG.ok("URL in request: {0}", request.getRequestLine().getUri());
+            LOG.ok("Enumerating headers");
+            for (Header header : request.getAllHeaders()) {
+                LOG.info("Headers.. name,value:{0},{1}", header.getName(), header.getValue());
+            }
         }
+
         try (CloseableHttpResponse response = executeRequest(request)) {
             processResponseErrors(response);
             if (response.getStatusLine().getStatusCode() == 204) {
@@ -578,7 +580,7 @@ public class GraphEndpoint {
 
         } catch (URISyntaxException e) {
             StringBuilder sb = new StringBuilder();
-            sb.append("It was not possible create URI from UriBuider:").append(uriBuilder).append(";")
+            sb.append("It was not possible create URI from UriBuilder:").append(uriBuilder).append(";")
                     .append(e.getLocalizedMessage());
             throw new ConnectorException(sb.toString(), e);
         }
@@ -708,7 +710,7 @@ public class GraphEndpoint {
             LOG.info("response {0}", response);
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode == 204) {
-                LOG.ok("204 - No content, Update was succesfull");
+                LOG.ok("204 - No content, Update was successful");
             } else {
                 LOG.error("Not updated, statusCode: {0}", statusCode);
             }
@@ -744,7 +746,7 @@ public class GraphEndpoint {
                 LOG.info("response {0}", response);
                 int statusCode = response.getStatusLine().getStatusCode();
                 if (statusCode == 204) {
-                    LOG.ok("204 - No content, Update was succesfull");
+                    LOG.ok("204 - No content, Update was successful");
                 } else {
                     LOG.error("Not updated, statusCode: {0}", statusCode);
                 }

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
@@ -311,7 +311,7 @@ public class GroupProcessing extends ObjectProcessing {
                     //POST https://graph.microsoft.com/v1.0/groups/{id}/members/$ref
                     //json.put(ATTR_ID, userID);
                     json.put("@odata.id", addToJson);
-                    LOG.ok("json: {0}", json.toString());
+                    LOG.ok("json: {0}", json);
                     postRequestNoContent(sbPath.toString(), json);
                 }
             }
@@ -344,7 +344,7 @@ public class GroupProcessing extends ObjectProcessing {
         JSONObject json = new JSONObject();
         String addToJson = "https://graph.microsoft.com/v1.0/directoryObjects/" + AttributeUtil.getAsStringValue(attribute);
         json.put("@odata.id", addToJson);
-        LOG.ok("json: {0}", json.toString());
+        LOG.ok("json: {0}", json);
         postRequestNoContent(sbPath.toString(), json);
     }
 
@@ -359,7 +359,7 @@ public class GroupProcessing extends ObjectProcessing {
         JSONObject json = new JSONObject();
         String addToJson = "https://graph.microsoft.com/v1.0/users/" + AttributeUtil.getAsStringValue(attribute);
         json.put("@odata.id", addToJson);
-        LOG.ok("json: {0}", json.toString());
+        LOG.ok("json: {0}", json);
         postRequestNoContent(sbPath.toString(), json);
     }
 
@@ -380,16 +380,22 @@ public class GroupProcessing extends ObjectProcessing {
         LOG.info("addOrRemoveMember {0} , {1} ", uid, attribute);
         StringBuilder sbPath = new StringBuilder();
         sbPath.append(GROUPS).append("/").append(uid.getUidValue()).append("/" + ATTR_OWNERS);
-        LOG.info("executeDeleteOperation userId: {0} , sbPath.toString: {1} ", AttributeUtil.getAsStringValue(attribute), sbPath.toString());
+        if (LOG.isInfo()) {
+            LOG.info("executeDeleteOperation userId: {0} , sbPath: {1} ", AttributeUtil.getAsStringValue(attribute), sbPath);
+        }
         executeDeleteOperation(new Uid(AttributeUtil.getAsStringValue(attribute)), sbPath.toString());
-        LOG.info("path: {0}", sbPath);
+        if (LOG.isInfo()) {
+            LOG.info("path: {0}", sbPath);
+        }
     }
 
     private void removeMemberFromGroup(Uid uid, Attribute attribute) {
         LOG.info("addOrRemoveMember {0} , {1} ", uid, attribute);
         StringBuilder sbPath = new StringBuilder();
         sbPath.append(GROUPS).append("/").append(uid.getUidValue()).append("/" + ATTR_MEMBERS);
-        LOG.info("executeDeleteOperation userId: {0} , sbPath.toString: {1} ", AttributeUtil.getAsStringValue(attribute), sbPath.toString());
+        if (LOG.isInfo()) {
+            LOG.info("executeDeleteOperation userId: {0} , sbPath: {1} ", AttributeUtil.getAsStringValue(attribute), sbPath);
+        }
         executeDeleteOperation(new Uid(AttributeUtil.getAsStringValue(attribute)), sbPath.toString());
         LOG.info("path: {0}", sbPath);
     }
@@ -415,12 +421,12 @@ public class GroupProcessing extends ObjectProcessing {
                     //POST https://graph.microsoft.com/v1.0/groups/{id}/owners/$ref
                     //json.put(ATTR_ID, userID);
                     json.put("@odata.id", addToJson);
-                    LOG.ok("json: {0}", json.toString());
+                    LOG.ok("json: {0}", json);
                     postRequestNoContent(sbPath.toString(), json);
                 }
             }
         }
-        LOG.info("sbPath : {0} ; removeValues {1} ", sbPath, removeValues);
+        LOG.info("sbPath : {0} ; removeValues {1}", sbPath, removeValues);
         groupProcessRemove(sbPath, removeValues);
     }
 
@@ -447,7 +453,7 @@ public class GroupProcessing extends ObjectProcessing {
                 if (removeValue != null) {
 
                     String userID = (String) removeValue;
-                    LOG.info("executeDeleteOperation userId: {0} , sbPath.toString: {1} ", userID, sbPath.toString());
+                    LOG.info("executeDeleteOperation userId: {0} , sbPath: {1} ", userID, sbPath);
                     executeDeleteOperation(new Uid(userID), sbPath.toString());
                 }
             }

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
@@ -4,15 +4,14 @@ import com.evolveum.polygon.connector.msgraphapi.util.ResourceQuery;
 import org.apache.http.client.methods.*;
 import org.apache.http.client.utils.URIBuilder;
 import org.identityconnectors.framework.common.exceptions.AlreadyExistsException;
-import org.identityconnectors.framework.common.exceptions.ConnectorException;
 import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
 import org.identityconnectors.framework.common.objects.*;
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.net.URI;
-import java.util.*;
+import java.util.List;
+import java.util.Set;
 
 public class GroupProcessing extends ObjectProcessing {
 
@@ -239,19 +238,15 @@ public class GroupProcessing extends ObjectProcessing {
                 .append("'")
                 .append("&$select=")
                 .append(getNameAttribute())
+                .append("&$top=1")
                 .toString();
-        final JSONObject groups = endpoint.executeGetRequest(GROUPS, query, new OperationOptionsBuilder().build(), false);
+        // Use "paging = false" with customQuery contains "$top=1" here since we want to check its existence only
+        final JSONArray groups = endpoint.executeListRequest(GROUPS, query, null, false);
 
-        JSONArray value;
-        try {
-            value = groups.getJSONArray("value");
-        } catch (JSONException e) {
-            throw new ConnectorException("No groups in JSON Array");
-        }
-        if (value.isEmpty()) {
+        if (groups.isEmpty()) {
             return false;
         }
-        String s = value.getJSONObject(0).getString(getNameAttribute());
+        String s = groups.getJSONObject(0).getString(getNameAttribute());
         return displayName.equalsIgnoreCase(s);
     }
 
@@ -511,22 +506,20 @@ public class GroupProcessing extends ObjectProcessing {
                 StringBuilder sbPath = new StringBuilder();
 
                 sbPath.append(GROUPS).append("/").append(query);
-                JSONObject group = endpoint.executeGetRequest(sbPath.toString(), null, options, false);
+                JSONObject group = endpoint.executeGetRequest(sbPath.toString(), null, options);
                 handleJSONObject(options, group, handler);
             } else {
 
                 if (translatedQuery.hasIdOrMembershipExpression()) {
 
                     LOG.ok("The constructed filter to be used: {0}", query);
-                    JSONObject groups = endpoint.executeGetRequest(translatedQuery.getIdOrMembershipExpression(), query, options,
-                            true);
-                    handleJSONArray(options, groups, handler);
+                    endpoint.executeListRequest(translatedQuery.getIdOrMembershipExpression(), query, options, true,
+                            createJSONObjectHandler(handler));
 
                 } else {
 
                     LOG.ok("The constructed filter about to being used: {0}", query);
-                    JSONObject groups = endpoint.executeGetRequest(GROUPS, query, options, true);
-                    handleJSONArray(options, groups, handler);
+                    endpoint.executeListRequest(GROUPS, query, options, true, createJSONObjectHandler(handler));
                 }
             }
 
@@ -534,51 +527,68 @@ public class GroupProcessing extends ObjectProcessing {
 
             LOG.info("Empty query, returning full list of objects for the {0} object class", ObjectClass.GROUP_NAME);
 
-            JSONObject groups = endpoint.executeGetRequest(GROUPS, null, options, true);
-            handleJSONArray(options, groups, handler);
+            endpoint.executeListRequest(GROUPS, null, options, true, createJSONObjectHandler(handler));
         }
     }
 
     /**
-     * Query a group's members and owners, add them to the group's JSON attributes (multivalue)
+     * Query a group's members, add them to the group's JSON attributes (multivalue)
      *
-     * @param options Operation options
-     * @param group   Group to query for (JSON object resulting from previous API call)
-     * @return Original JSON, enriched with member/owner information
+     * @param group Group to query for (JSON object resulting from previous API call)
+     * @return Original JSON, enriched with member information
      */
-    private JSONObject saturateGroupMembership(OperationOptions options, JSONObject group) {
+    private JSONObject saturateGroupMembership(JSONObject group) {
         final GraphEndpoint endpoint = getGraphEndpoint();
         final String uid = group.getString(ATTR_ID);
 
         //get list of group members
-        if (getSchemaTranslator().containsToGet(ObjectClass.GROUP_NAME, options, ATTR_MEMBERS)) {
-            final String memberQuery = new StringBuilder()
-                    .append(GROUPS).append("/").append(uid).append("/")
-                    .append(ATTR_MEMBERS).toString();
-            final JSONObject groupMembers = endpoint.executeGetRequest(memberQuery, "$select=id,userPrincipalName", null, false);
-            group.put(ATTR_MEMBERS, getJSONArray(groupMembers, "id"));
-        }
+        final String memberQuery = new StringBuilder()
+                .append(GROUPS).append("/").append(uid).append("/")
+                .append(ATTR_MEMBERS).toString();
+        final JSONArray groupMembers = endpoint.executeListRequest(memberQuery, "$select=id,userPrincipalName", null, true);
+        group.put(ATTR_MEMBERS, getJSONArray(groupMembers, "id"));
+
+        return group;
+    }
+
+    /**
+     * Query a group's owners, add them to the group's JSON attributes (multivalue)
+     *
+     * @param group Group to query for (JSON object resulting from previous API call)
+     * @return Original JSON, enriched with owner information
+     */
+    private JSONObject saturateGroupOwnership(JSONObject group) {
+        final GraphEndpoint endpoint = getGraphEndpoint();
+        final String uid = group.getString(ATTR_ID);
 
         //get list of group owners
-        if (getSchemaTranslator().containsToGet(ObjectClass.GROUP_NAME, options, ATTR_OWNERS)) {
-            final String ownerQuery = new StringBuilder()
-                    .append(GROUPS).append("/").append(uid).append("/")
-                    .append(ATTR_OWNERS).toString();
-            final JSONObject groupOwners = endpoint.executeGetRequest(ownerQuery, "$select=id,userPrincipalName", null, false);
-            group.put(ATTR_OWNERS, getJSONArray(groupOwners, "id"));
-        }
+        final String ownerQuery = new StringBuilder()
+                .append(GROUPS).append("/").append(uid).append("/")
+                .append(ATTR_OWNERS).toString();
+        final JSONArray groupOwners = endpoint.executeListRequest(ownerQuery, "$select=id,userPrincipalName", null, true);
+        group.put(ATTR_OWNERS, getJSONArray(groupOwners, "id"));
 
         return group;
     }
 
     @Override
     protected boolean handleJSONObject(OperationOptions options, JSONObject group, ResultsHandler handler) {
-        LOG.ok("processingObjectFromGET (Object)");
-        if (!Boolean.TRUE.equals(options.getAllowPartialAttributeValues())) {
-            group = saturateGroupMembership(options, group);
+        LOG.ok("handleJSONObject");
+        if (shouldSaturate(options, ObjectClass.GROUP_NAME, ATTR_MEMBERS)) {
+            group = saturateGroupMembership(group);
         }
-        final ConnectorObject connectorObject = convertGroupJSONObjectToConnectorObject(group).build();
-        LOG.ok("processingGroupObjectFromGET, group: {0}, \n\tconnectorObject: {1}", group.get("id"), connectorObject.toString());
+
+        if (shouldSaturate(options, ObjectClass.GROUP_NAME, ATTR_OWNERS)) {
+            group = saturateGroupOwnership(group);
+        }
+
+        ConnectorObjectBuilder builder = convertGroupJSONObjectToConnectorObject(group);
+
+        incompleteIfNecessary(options, ObjectClass.GROUP_NAME, ATTR_MEMBERS, builder);
+        incompleteIfNecessary(options, ObjectClass.GROUP_NAME, ATTR_OWNERS, builder);
+
+        final ConnectorObject connectorObject = builder.build();
+        LOG.ok("handleJSONObject, group: {0}, \n\tconnectorObject: {1}", group.get("id"), connectorObject);
         return handler.handle(connectorObject);
     }
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -18,6 +18,7 @@ import org.identityconnectors.framework.common.objects.SchemaBuilder;
 import org.identityconnectors.framework.common.objects.Uid;
 import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
 import org.identityconnectors.framework.common.objects.filter.Filter;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 
@@ -119,8 +120,8 @@ public class LicenseProcessing extends ObjectProcessing {
 
     private void get(ResultsHandler handler, String skuId, OperationOptions options) {
         final GraphEndpoint endpoint = getGraphEndpoint();
-        JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS + "/" + skuId, SELECTOR_FULL, options, false);
-        LOG.info("JSONObject license {0}", json.toString());
+        JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS + "/" + skuId, SELECTOR_FULL, options);
+        LOG.info("JSONObject license {0}", json);
         handleJSONObject(options, json, handler);
     }
 
@@ -129,15 +130,15 @@ public class LicenseProcessing extends ObjectProcessing {
         String selector = SELECTOR_FULL;
         if (options != null && options.getAllowPartialAttributeValues() != null && options.getAllowPartialAttributeValues())
             selector = SELECTOR_PARTIAL;
-        JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS, selector, options, false);
-        LOG.info("JSONObject license {0}", json.toString());
-        handleJSONArray(options, json, handler);
+        // Paging is not supported
+        endpoint.executeListRequest(GRAPH_SUBSCRIBEDSKUS, selector, options, false, createJSONObjectHandler(handler));
     }
 
     public List<JSONObject> list() {
         final GraphEndpoint endpoint = getGraphEndpoint();
-        JSONObject json = endpoint.executeGetRequest(GRAPH_SUBSCRIBEDSKUS, SELECTOR_FULL, null, false);
-        LOG.info("JSONObject license {0}", json.toString());
+        // Paging is not supported
+        JSONArray json = endpoint.executeListRequest(GRAPH_SUBSCRIBEDSKUS, SELECTOR_FULL, null, false);
+        LOG.info("JSONObject license {0}", json);
         return handleJSONArray(json);
     }
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
@@ -5,32 +5,25 @@ package com.evolveum.polygon.connector.msgraphapi;
 import com.evolveum.polygon.connector.msgraphapi.util.FilterHandler;
 import com.evolveum.polygon.connector.msgraphapi.util.ResourceQuery;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.client.methods.HttpRequestBase;
-//import org.apache.http.*;
-//import org.apache.http.protocol.*;
-//import org.apache.http.client.protocol.HttpClientContext;
-//import org.apache.http.client.methods.*;
-//import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
-//import org.apache.http.client.*;
-//import org.apache.http.impl.client.*;
-import org.identityconnectors.framework.common.exceptions.ConnectionFailedException;
-import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
-import org.identityconnectors.framework.spi.PoolableConnector;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.JSONArray;
+import org.apache.http.client.utils.URIBuilder;
 import org.identityconnectors.common.CollectionUtil;
 import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.framework.common.exceptions.ConnectionFailedException;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
 import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
 import org.identityconnectors.framework.common.objects.*;
+import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
 import org.identityconnectors.framework.common.objects.filter.Filter;
 import org.identityconnectors.framework.common.objects.filter.FilterTranslator;
 import org.identityconnectors.framework.spi.Configuration;
 import org.identityconnectors.framework.spi.Connector;
 import org.identityconnectors.framework.spi.ConnectorClass;
+import org.identityconnectors.framework.spi.PoolableConnector;
 import org.identityconnectors.framework.spi.operations.*;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -188,7 +181,7 @@ public class MSGraphConnector implements Connector,
             uriBuilder.setCustomQuery(customQuery + "&" + selector);
             uriBuilder.setCustomQuery(customQuery);
             uriBuilder.setPath(getPath);
-            LOG.info("Get latest sync token uri is {0} ", uriBuilder.toString());
+            LOG.info("Get latest sync token uri is {0} ", uriBuilder);
             try {
                 URI uri = uriBuilder.build();
                 HttpGet syncTokenRequest = new HttpGet(uri);
@@ -435,10 +428,11 @@ public class MSGraphConnector implements Connector,
                 }
             }
 
-            LOG.ok("Query will be executed with the following filter: {0}", translatedQuery.toString() != null ?
-                    translatedQuery.toString() : translatedQuery.getIdOrMembershipExpression());
-
-            LOG.ok("The object class for which the filter will be executed: {0}", objectClass.getDisplayNameKey());
+            if (LOG.isOk()) {
+                LOG.ok("Query will be executed with the following filter: {0}", translatedQuery.toString() != null ?
+                        translatedQuery : translatedQuery.getIdOrMembershipExpression());
+                LOG.ok("The object class for which the filter will be executed: {0}", objectClass.getDisplayNameKey());
+            }
 
             userProcessing.executeQueryForUser(translatedQuery, fetchSpecificObject ,handler, options);
 
@@ -455,8 +449,10 @@ public class MSGraphConnector implements Connector,
                 }
             }
 
-            LOG.ok("Query will be executed with the following filter: {0}", translatedQuery.toString());
-            LOG.ok("The object class for which the filter will be executed: {0}", objectClass.getDisplayNameKey());
+            if (LOG.isOk()) {
+                LOG.ok("Query will be executed with the following filter: {0}", translatedQuery);
+                LOG.ok("The object class for which the filter will be executed: {0}", objectClass.getDisplayNameKey());
+            }
 
             groupProcessing.executeQueryForGroup(translatedQuery, fetchSpecificObject, handler, options);
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessing.java
@@ -267,7 +267,7 @@ abstract class ObjectProcessing {
 
 
     protected String getUIDIfExists(JSONObject object, String nameAttr, ConnectorObjectBuilder builder) {
-        LOG.ok("getUIDIfExists nameAttr: {0} bulder {1}", nameAttr, builder.toString());
+        LOG.ok("getUIDIfExists nameAttr: {0} builder {1}", nameAttr, builder);
         if (object.has(nameAttr)) {
             String uid = object.getString(nameAttr);
             builder.setUid(new Uid(String.valueOf(uid)));

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessing.java
@@ -159,7 +159,7 @@ public class RoleProcessing extends ObjectProcessing {
                     json.put("directoryScopeId", directoryScopeId);
                     json.put("roleDefinitionId", roleDefinitionId);
 
-                    LOG.ok("json: {0}", json.toString());
+                    LOG.ok("json: {0}", json);
                     postRequestNoContent(sbPath.toString(), json);
                 }
             }
@@ -193,7 +193,7 @@ public class RoleProcessing extends ObjectProcessing {
         json.put("directoryScopeId", directoryScopeId);
         json.put("roleDefinitionId", roleDefinitionId);
 
-        LOG.ok("json: {0}", json.toString());
+        LOG.ok("json: {0}", json);
         postRequestNoContent(sbPath.toString(), json);
     }
 
@@ -208,19 +208,19 @@ public class RoleProcessing extends ObjectProcessing {
     }
 
     private void removeMemberFromRole(Uid uid, Attribute attribute, OperationOptions options) {
-        LOG.info("addOrRemoveMember {0} , {1} ", uid, attribute);
+        LOG.info("addOrRemoveMember {0} , {1}", uid, attribute);
         StringBuilder sbPath = new StringBuilder();
         sbPath.append(ROLE_ASSIGNMENT);
 
         String roleDefinitionId = uid.getUidValue();
         String principalId = AttributeUtil.getAsStringValue(attribute);
         String roleAssignmentId = getRoleAssignmentId(options, roleDefinitionId, principalId);
-        LOG.info("executeDeleteOperation principalId: {0} , sbPath.toString: {1} ", principalId, sbPath.toString());
+        LOG.info("executeDeleteOperation principalId: {0} , sbPath: {1}", principalId, sbPath);
         executeDeleteOperation(roleAssignmentId, sbPath.toString());
     }
 
     private void postRequestNoContent(String path, JSONObject json) {
-        LOG.info("path: {0} , json {1}, ", path, json);
+        LOG.info("path: {0} , json: {1}", path, json);
         final GraphEndpoint endpoint = getGraphEndpoint();
         final URIBuilder uriBuilder = endpoint.createURIBuilder().setPath(path);
         final URI uri = endpoint.getUri(uriBuilder);
@@ -243,7 +243,7 @@ public class RoleProcessing extends ObjectProcessing {
 
                     String principalId = (String) removeValue;
                     String roleAssignmentId = getRoleAssignmentId(options, roleDefinitionId, principalId);
-                    LOG.info("executeDeleteOperation principalId: {0} , sbPath.toString: {1} ", principalId, sbPath.toString());
+                    LOG.info("executeDeleteOperation principalId: {0} , sbPath: {1}", principalId, sbPath);
                     executeDeleteOperation(roleAssignmentId, sbPath.toString());
                 }
             }

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessing.java
@@ -17,7 +17,7 @@ public class RoleProcessing extends ObjectProcessing {
     public static final String ROLE_NAME = "Role";
     public static final ObjectClass ROLE = new ObjectClass(ROLE_NAME);
 
-    private final static String ROLES = "/roleManagement/directory/roleDefinitions";
+    private final static String ROLES = "/roleManagement/directory/roleDefinitions"; // Paging is not supported
     private final static String ROLE_ASSIGNMENT = "/roleManagement/directory/roleAssignments";
     private final static String USERS = "/users";
 
@@ -283,8 +283,8 @@ public class RoleProcessing extends ObjectProcessing {
                 StringBuilder sbPath = new StringBuilder();
                 sbPath.append(ROLES).append("/").append(uid.getUidValue());
 
-                JSONObject roles = endpoint.executeGetRequest(sbPath.toString(), null, options, false);
-                handleJSONObject(options, roles, handler);
+                JSONObject role = endpoint.executeGetRequest(sbPath.toString(), null, options);
+                handleJSONObject(options, role, handler);
             } else if (equalsFilter.getAttribute() instanceof Name) {
                 LOG.info("((EqualsFilter) query).getAttribute() instanceof Name");
 
@@ -294,13 +294,13 @@ public class RoleProcessing extends ObjectProcessing {
                     invalidAttributeValue("Name", query);
                 }
                 final String customQuery = "$filter=" + ATTR_DISPLAY_NAME + " eq '" + nameValue + "'";
-                final JSONObject roles = endpoint.executeGetRequest(ROLES, customQuery, options, true);
-                handleJSONArray(options, roles, handler);
+                // Paging is not supported
+                endpoint.executeListRequest(ROLES, customQuery, options, false, createJSONObjectHandler(handler));
             } else if (ATTR_DISPLAY_NAME.equals(attributeName)) {
                 final String attributeValue = getAttributeFirstValue(equalsFilter);
                 final String customQuery = "$filter=" + attributeName + " eq '" + attributeValue + "'";
-                final JSONObject roles = endpoint.executeGetRequest(ROLES, customQuery, options, true);
-                handleJSONArray(options, roles, handler);
+                // Paging is not supported
+                endpoint.executeListRequest(ROLES, customQuery, options, false, createJSONObjectHandler(handler));
             }
         } else if (query instanceof ContainsFilter) {
             LOG.info("Query is instance of ContainsFilter: {0}", query);
@@ -309,8 +309,8 @@ public class RoleProcessing extends ObjectProcessing {
             final String attributeValue = getAttributeFirstValue(containsFilter);
             if (Arrays.asList(ATTR_DISPLAY_NAME).contains(attributeName)) {
                 String customQuery = "$filter=" + STARTSWITH + "(" + attributeName + ",'" + attributeValue + "')";
-                JSONObject roles = endpoint.executeGetRequest(ROLES, customQuery, options, true);
-                handleJSONArray(options, roles, handler);
+                // Paging is not supported
+                endpoint.executeListRequest(ROLES, customQuery, options, false, createJSONObjectHandler(handler));
             }
         } else if (query instanceof ContainsAllValuesFilter) {
             LOG.info("[QUERY] - ContainsAllValuesFilter - query: {0}", query);
@@ -319,64 +319,51 @@ public class RoleProcessing extends ObjectProcessing {
             final String attributeValue = getAttributeFirstValue(containsAllValuesFilter);
             LOG.info("[QUERY] - ContainsAllValuesFilter - name is: {0} and value is: {1}", attributeName, attributeValue);
 
-            ArrayList<String> roleUIDs = saturateUserRoleMembership(options, attributeValue);
-            JSONObject groups = new JSONObject();
-            groups.put("value", new JSONArray());
+            listUserRoleMembership(options, attributeValue, (opt, object) -> {
+                String roleUID = object.getString("roleDefinitionId");
+                LOG.info("[QUERY] - ContainsAllValuesFilter - roleUID: {0}", roleUID);
 
-            LOG.info("[QUERY] - ContainsAllValuesFilter - roleUIDs: {0}", roleUIDs);
-
-            for (String roleUID : roleUIDs) {
                 String getPath = ROLES + "/" + roleUID;
-                JSONObject group = endpoint.executeGetRequest(getPath, null, options, false);
-                groups.append("value", group);
-            }
+                JSONObject role = endpoint.executeGetRequest(getPath, null, options);
 
-            LOG.info("[QUERY] - ContainsAllValuesFilter - groups: {0}", groups);
-
-            handleJSONArray(options, groups, handler);
+                return handleJSONObject(opt, role, handler);
+            });
         } else if (query == null) {
             LOG.info("Query is null");
-            JSONObject roles = endpoint.executeGetRequest(ROLES, null, options, true);
-            handleJSONArray(options, roles, handler);
+            // Paging is not supported
+            endpoint.executeListRequest(ROLES, null, options, false, createJSONObjectHandler(handler));
         }
     }
 
     /**
      * Query a role's members, add them to the group's JSON attributes (multivalue)
      *
-     * @param options Operation options
      * @param role Role to query for (JSON object resulting from previous API call)
      *
      * @return Original JSON, enriched with member information
      */
-    private JSONObject saturateRoleMembership(OperationOptions options, JSONObject role) {
+    private JSONObject saturateRoleMembership(JSONObject role) {
         final GraphEndpoint endpoint = getGraphEndpoint();
         final String uid = role.getString(ATTR_ID);
 
-        if (getSchemaTranslator().containsToGet(RoleProcessing.ROLE_NAME, options, ATTR_MEMBERS)) {
-            LOG.info("[GET] - saturateRoleMembership(), for role with UID: {0}", uid);
+        LOG.info("[GET] - saturateRoleMembership(), for role with UID: {0}", uid);
 
-            //get list of role members
-            final String customQuery = "$filter=roleDefinitionId eq '" + uid + "'";
-            final JSONObject roleMembers = endpoint.executeGetRequest(ROLE_ASSIGNMENT, customQuery, options, false);
-            role.put(ATTR_MEMBERS, getJSONArray(roleMembers, "principalId"));
-        }
+        //get list of role members
+        final String customQuery = "$select=principalId&$filter=roleDefinitionId eq '" + uid + "'";
+        final JSONArray roleMembers = endpoint.executeListRequest(ROLE_ASSIGNMENT, customQuery, null, true);
+        role.put(ATTR_MEMBERS, getJSONArray(roleMembers, "principalId"));
 
         return role;
     }
 
-    private ArrayList<String> saturateUserRoleMembership(OperationOptions options, String principalId) {
+    private void listUserRoleMembership(OperationOptions options, String principalId, JSONObjectHandler handler) {
         final GraphEndpoint endpoint = getGraphEndpoint();
 
-        LOG.info("[GET] - saturateUsersRoleMembership(), for user with UID: {0}", principalId);
+        LOG.info("[GET] - listUserRoleMembership(), for user with UID: {0}", principalId);
 
         //get list of roles where the user is memberOf
-        final String customQuery = "$filter=principalId eq '" + principalId + "'";
-        final JSONObject roleMembers = endpoint.executeGetRequest(ROLE_ASSIGNMENT, customQuery, options, false);
-
-        LOG.info("[GET] - roleMembers: {0}", roleMembers);
-
-        return getArrayList(roleMembers, "roleDefinitionId");
+        final String customQuery = "$select=roleDefinitionId&$filter=principalId eq '" + principalId + "'";
+        endpoint.executeListRequest(ROLE_ASSIGNMENT, customQuery, options, true, handler);
     }
 
     private String getRoleAssignmentId(OperationOptions options, String roleDefinitionId, String principalId) {
@@ -385,8 +372,8 @@ public class RoleProcessing extends ObjectProcessing {
         LOG.info("[GET] - getRoleAssignmentId(), for role with UID: {0}", roleDefinitionId);
 
         //get exactly one roleAssignment by roleDefinitionId and principalId
-        final String customQuery = "$filter=roleDefinitionId eq '" + roleDefinitionId + "' and principalId eq '" + principalId + "'";
-        final JSONObject roleMembers = endpoint.executeGetRequest(ROLE_ASSIGNMENT, customQuery, options, false);
+        final String customQuery = "$select=id&$filter=roleDefinitionId eq '" + roleDefinitionId + "' and principalId eq '" + principalId + "'";
+        final JSONArray roleMembers = endpoint.executeListRequest(ROLE_ASSIGNMENT, customQuery, options, true);
 
         LOG.info("[GET] - roleMembers: {0}", roleMembers);
 
@@ -397,12 +384,16 @@ public class RoleProcessing extends ObjectProcessing {
     protected boolean handleJSONObject(OperationOptions options, JSONObject role, ResultsHandler handler) {
         LOG.info("processingRoleObjectFromGET (Object)");
 
-        if (!Boolean.TRUE.equals(options.getAllowPartialAttributeValues())) {
-            role = saturateRoleMembership(options, role);
+        if (shouldSaturate(options, RoleProcessing.ROLE_NAME, ATTR_MEMBERS)) {
+            role = saturateRoleMembership(role);
         }
 
-        final ConnectorObject connectorObject = convertRoleJSONObjectToConnectorObject(role).build();
-        LOG.info("processingRoleObjectFromGET, role: {0}, \n\tconnectorObject: {1}", role.get("id"), connectorObject.toString());
+        ConnectorObjectBuilder builder = convertRoleJSONObjectToConnectorObject(role);
+
+        incompleteIfNecessary(options, RoleProcessing.ROLE_NAME, ATTR_MEMBERS, builder);
+
+        final ConnectorObject connectorObject = builder.build();
+        LOG.info("processingRoleObjectFromGET, role: {0}, \n\tconnectorObject: {1}", role.get("id"), connectorObject);
         return handler.handle(connectorObject);
     }
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -1018,7 +1018,7 @@ public class UserProcessing extends ObjectProcessing {
                     });
                 }
 
-                LOG.ok("The retrieved JSONObject for the account {0}: {1}", query, user.toString());
+                LOG.ok("The retrieved JSONObject for the account {0}: {1}", query, user);
                 handleJSONObject(options, user, handler);
 
             } else {
@@ -1094,7 +1094,6 @@ public class UserProcessing extends ObjectProcessing {
         incompleteIfNecessary(options, ObjectClass.ACCOUNT_NAME, ATTR_MEMBER_OF_ROLE, builder);
 
         ConnectorObject connectorObject = builder.build();
-
         LOG.info("convertUserToConnectorObject, user: {0}, \n\tconnectorObject: {1}", user.get("id"), connectorObject);
         return handler.handle(connectorObject);
     }

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/util/FilterHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/util/FilterHandler.java
@@ -107,7 +107,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
         Iterator<String> keyIterator = items.iterator();
 
         LOG.ok("Evaluation of AND filter expression: {0}. With previously constructed filter snippet: {1}",
-                andFilter, p.toString());
+                andFilter, p);
         while (keyIterator.hasNext()) {
 
             String snipp = keyIterator.next();
@@ -167,7 +167,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
         if (wasFirst) {
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 
@@ -202,7 +202,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
         if (!afterFirtsOperation) {
             p.setSearchExpression(snippet);
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 
@@ -282,7 +282,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             p.setFilterExpression(snippet);
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 
@@ -317,7 +317,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             p.setFilterExpression(snippet);
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 
@@ -342,7 +342,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             p.setFilterExpression(snippet);
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 
@@ -368,7 +368,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             p.setFilterExpression(snippet);
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 
@@ -379,8 +379,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
     @Override
     public ResourceQuery visitLessThanOrEqualFilter(ResourceQuery p, LessThanOrEqualFilter lessThanOrEqualFilter) {
 
-        LOG.ok("Processing through LESS THAN OR EQUAL FILTER filter expression"
-                , p);
+        LOG.ok("Processing through LESS THAN OR EQUAL FILTER filter expression");
 
         if (afterFirtsOperation) {
             checkFilterConditions();
@@ -395,7 +394,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             p.setFilterExpression(snippet);
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 
@@ -406,7 +405,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
     @Override
     public ResourceQuery visitNotFilter(ResourceQuery p, NotFilter notFilter) {
 
-        LOG.ok("Processing through NOT filter expression {0}:", notFilter);
+        LOG.ok("Processing through NOT filter expression {0}", notFilter);
 
         Boolean wasFirst = !afterFirtsOperation;
 
@@ -423,7 +422,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
         Map<String, CategorizedFilter> processed = processCompositeFilter(filters, p);
 
         LOG.ok("Evaluating NOT filter expression {0}. With previously constructed filter snippet: {1}",
-                notFilter, p.toString());
+                notFilter, p);
 
         if (!processed.isEmpty()) {
             for (String snipp : processed.keySet()) {
@@ -482,15 +481,14 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
                 }
             }
         } else {
-
-            LOG.warn("Invalid filter state, potentially malformed query snippet: {0}", query.toString());
+            LOG.warn("Invalid filter state, potentially malformed query snippet: {0}", query);
         }
 
           if (wasFirst) {
 
             p.setFilterExpression(query.toString());
 
-            LOG.ok("Generated final query snippet: {0}", p.toString());
+            LOG.ok("Generated final query snippet: {0}", p);
             return p;
         }
 
@@ -536,7 +534,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
         Iterator<String> keyIterator = items.iterator();
 
         LOG.ok("Evaluation of OR filter expression: {0}. With previously constructed filter snippet: {1}",
-                orFilter, p.toString());
+                orFilter, p);
 
         while (keyIterator.hasNext()) {
 
@@ -595,8 +593,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
         }
 
         if (wasFirst) {
-
-            LOG.ok("Generated query snippet for OR OP used: {0}", p.toString());
+            LOG.ok("Generated query snippet for OR OP used: {0}", p);
             return p;
         }
 
@@ -627,7 +624,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             p.setFilterExpression(snippet);
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 
@@ -654,7 +651,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             p.setFilterExpression(snippet);
 
-            LOG.ok("Generated query snippet: {0}", p.toString());
+            LOG.ok("Generated query snippet: {0}", p);
             return p;
         }
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/util/ResourceQuery.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/util/ResourceQuery.java
@@ -118,35 +118,36 @@ public class ResourceQuery {
 
         return "";
     }
-@Override
-public String toString() {
 
-    //   evaluateAggregated();
+    @Override
+    public String toString() {
 
-    if (!(filterExpression != null && !filterExpression.isEmpty()) && !(searchExpression != null &&
-            !searchExpression.isEmpty())) {
+        //   evaluateAggregated();
 
-        return null;
+        if (!(filterExpression != null && !filterExpression.isEmpty()) && !(searchExpression != null &&
+                !searchExpression.isEmpty())) {
+
+            return null;
+        }
+
+        if ((filterExpression != null && !filterExpression.isEmpty()) && (searchExpression != null &&
+                !searchExpression.isEmpty())) {
+
+            String returnExpression = $_FILTER + filterExpression + _AMP + $_SEARCH + searchExpression;
+
+            return returnExpression;
+        }
+
+        if (filterExpression != null && !filterExpression.isEmpty()) {
+
+            String returnExpression = $_FILTER + filterExpression + appendCount();
+
+            return returnExpression;
+        }
+
+
+        return $_SEARCH + searchExpression;
     }
-
-    if ((filterExpression != null && !filterExpression.isEmpty()) && (searchExpression != null &&
-            !searchExpression.isEmpty())) {
-
-        String returnExpression = $_FILTER + filterExpression + _AMP + $_SEARCH + searchExpression;
-
-        return returnExpression;
-    }
-
-    if (filterExpression != null && !filterExpression.isEmpty()) {
-
-        String returnExpression = $_FILTER + filterExpression + appendCount();
-
-        return returnExpression;
-    }
-
-
-    return $_SEARCH + searchExpression;
-}
 
 
     private void evaluateAggregated() {

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessingTest.java
@@ -28,7 +28,7 @@ public class GroupProcessingTest extends BasicConfigurationForTests {
     @Test
     public void testParseGroupMembers() throws Exception {
         final JSONObject membersJson = parseResource("groupMembers.json");
-        final JSONArray jarr = groupProcessing.getJSONArray(membersJson, "id");
+        final JSONArray jarr = groupProcessing.getJSONArray(membersJson.getJSONArray("value"), "id");
         final List<Object> ids = jarr.toList();
         Assert.assertEquals(2, ids.size());
         Assert.assertEquals("9639bcbc-0089-4855-a793-44b940e52286", ids.get(0));

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessingTest.java
@@ -28,7 +28,7 @@ public class RoleProcessingTest extends BasicConfigurationForTests {
     @Test
     public void testParseGroupMembers() throws Exception {
         final JSONObject membersJson = parseResource("groupMembers.json");
-        final JSONArray jarr = roleProcessing.getJSONArray(membersJson, "id");
+        final JSONArray jarr = roleProcessing.getJSONArray(membersJson.getJSONArray("value"), "id");
         final List<Object> ids = jarr.toList();
         Assert.assertEquals(2, ids.size());
         Assert.assertEquals("9639bcbc-0089-4855-a793-44b940e52286", ids.get(0));


### PR DESCRIPTION
I have made the following improvements:

## [Improved query processing](https://github.com/Evolveum/connector-microsoft-graph-api/commit/b30205cac5cb19f66c0a92219b520706869167d1)

- Currently, when processing queries with paging, the results are all held in memory before being processed by the ResultHandler, which is inefficient with regard to memory usage when there are large result sets.
- Fixed page size being obtained from OperationOptions incorrectly, but now it is obtained from the connector configuration.
- Fixed incorrect retrieval of member if it exceeds the default paging size (100).
- Fixed not returning incomplete result when `ALLOW_PARTIAL_ATTRIBUTE_VALUES` is true.

## [Fixed unnecessary string conversion in logging, fixed typo and indent](https://github.com/Evolveum/connector-microsoft-graph-api/commit/993e21e3493e52522f01e934245213fe0a843b60)

- Fixed unnecessary string conversion in logging.
- Fixed typo and indent.
