### PR TITLE
Improved build process for JSON object

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessing.java
@@ -10,6 +10,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -50,10 +51,15 @@ public class GroupProcessing extends ObjectProcessing {
     }
 
     @Override
+    protected String type() {
+        return ObjectClass.GROUP_NAME;
+    }
+
+    @Override
     protected ObjectClassInfo objectClassInfo() {
         ObjectClassInfoBuilder groupObjClassBuilder = new ObjectClassInfoBuilder();
 
-        groupObjClassBuilder.setType(ObjectClass.GROUP_NAME);
+        groupObjClassBuilder.setType(type());
 
         //required
 
@@ -210,7 +216,7 @@ public class GroupProcessing extends ObjectProcessing {
             LOG.info("Uid != null -> update group");
             LOG.info("Path: {0}", uri);
             request = new HttpPatch(uri);
-            List<Object> attributeList = buildLayeredAtrribute(attributes);
+            List<JSONObject> attributeList = buildLayeredAttribute(attributes, Collections.emptySet());
             endpoint.callRequestNoContentNoJson(request, attributeList);
         }
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -73,6 +73,11 @@ public class LicenseProcessing extends ObjectProcessing {
     }
 
     @Override
+    protected String type() {
+        return OBJECT_CLASS_NAME;
+    }
+
+    @Override
     protected ObjectClassInfo objectClassInfo() {
         Set<AttributeInfo> attributes = new HashSet<>();
 
@@ -112,7 +117,7 @@ public class LicenseProcessing extends ObjectProcessing {
                 .setMultiValued(true)
                 .build());
         return new ObjectClassInfoBuilder()
-                .setType(OBJECT_CLASS_NAME)
+                .setType(type())
                 .addAllAttributeInfo(attributes)
                 .build();
     }

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConnector.java
@@ -530,7 +530,9 @@ public class MSGraphConnector implements Connector,
         for (AttributeDelta attrDelta : attrsDelta) {
             List<Object> replaceValue = attrDelta.getValuesToReplace();
             if (replaceValue != null) {
-                LOG.info("attributeReplace.add {0} {1}", AttributeBuilder.build(attrDelta.getName(), replaceValue));
+                if (LOG.isInfo()) {
+                    LOG.info("attributeReplace.add {0} {1}", AttributeBuilder.build(attrDelta.getName(), replaceValue));
+                }
                 attributeReplace.add(AttributeBuilder.build(attrDelta.getName(), replaceValue));
             } else {
                 LOG.info("attrsDeltaMultivalue.add {0}", attrDelta);

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessing.java
@@ -49,10 +49,15 @@ public class RoleProcessing extends ObjectProcessing {
     }
 
     @Override
+    protected String type() {
+        return ROLE_NAME;
+    }
+
+    @Override
     protected ObjectClassInfo objectClassInfo() {
         ObjectClassInfoBuilder roleObjClassBuilder = new ObjectClassInfoBuilder();
 
-        roleObjClassBuilder.setType(RoleProcessing.ROLE_NAME);
+        roleObjClassBuilder.setType(type());
 
         // required attribute is icfs:name and icfs:uid
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslator.java
@@ -48,6 +48,10 @@ public class SchemaTranslator {
         return rawConnIdSchema;
     }
 
+    public Map<String, Map<String, AttributeInfo>> getConnIdSchemaMap() {
+        return connIdSchema;
+    }
+
     public String[] filter(String type, OperationOptions options, String... attrs) {
         Set<String> returnedAttributes = getAttributesToGet(type, options);
 

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -168,7 +168,9 @@ public class UserProcessing extends ObjectProcessing {
     // technical constants
     private static final String TYPE = "@odata.type";
     private static final String TYPE_GROUP = "#microsoft.graph.group";
-    private static final Set<String> OPTIONAL_ATTRS = Stream.of(
+
+    // SPO(SharePoint Online) attributes
+    protected static final Set<String> SPO_ATTRS = Stream.of(
             ATTR_ABOUTME,
             ATTR_BIRTHDAY,
             ATTR_HIREDATE,
@@ -203,9 +205,14 @@ public class UserProcessing extends ObjectProcessing {
     }
 
     @Override
+    protected String type() {
+        return ObjectClass.ACCOUNT_NAME;
+    }
+
+    @Override
     protected ObjectClassInfo objectClassInfo() {
         ObjectClassInfoBuilder userObjClassBuilder = new ObjectClassInfoBuilder();
-        userObjClassBuilder.setType(ObjectClass.ACCOUNT_NAME);
+        userObjClassBuilder.setType(type());
 
         userObjClassBuilder.addAttributeInfo(OperationalAttributeInfos.ENABLE);
         userObjClassBuilder.addAttributeInfo(OperationalAttributeInfos.PASSWORD);
@@ -846,7 +853,8 @@ public class UserProcessing extends ObjectProcessing {
         final Attribute userPhoto = attributes.stream()
                 .filter(a -> a.is(ATTR_USERPHOTO))
                 .findFirst().orElse(null);
-        List<Object> jsonObjectaccount = buildLayeredAtrribute(updateAttributes);
+
+        List<JSONObject> jsonObjectaccount = buildLayeredAttribute(updateAttributes, SPO_ATTRS);
         endpoint.callRequestNoContentNoJson(request, jsonObjectaccount);
         assignLicenses(uid, AttributeDeltaUtil.find(ATTR_ASSIGNEDLICENSES__SKUID, deltas));
         assignManager(uid, manager);

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/GroupProcessingTest.java
@@ -2,14 +2,20 @@ package com.evolveum.polygon.connector.msgraphapi;
 
 import com.evolveum.polygon.connector.msgraphapi.integration.BasicConfigurationForTests;
 import org.apache.commons.io.IOUtils;
+import org.identityconnectors.framework.common.objects.Attribute;
+import org.identityconnectors.framework.common.objects.AttributeBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Test case for {@link GroupProcessing}
@@ -17,21 +23,48 @@ import java.util.List;
 @Test(groups = "unit")
 public class GroupProcessingTest extends BasicConfigurationForTests {
 
-    private JSONObject parseResource(String fileName) throws IOException  {
+    private JSONObject parseResource(String fileName) throws IOException {
         try (InputStream is = getClass().getResourceAsStream(fileName)) {
             return new JSONObject(IOUtils.toString(is));
         }
     }
 
-    final GroupProcessing groupProcessing = new GroupProcessing(new GraphEndpoint(getConfiguration()));
+    final GroupProcessing groupProcessing = new GroupProcessing(new MockGraphEndpoint(null));
 
     @Test
     public void testParseGroupMembers() throws Exception {
         final JSONObject membersJson = parseResource("groupMembers.json");
         final JSONArray jarr = groupProcessing.getJSONArray(membersJson.getJSONArray("value"), "id");
         final List<Object> ids = jarr.toList();
-        Assert.assertEquals(2, ids.size());
-        Assert.assertEquals("9639bcbc-0089-4855-a793-44b940e52286", ids.get(0));
-        Assert.assertEquals("f034f71e-22a8-489b-8492-f5f7133559c1", ids.get(1));
+        assertEquals(2, ids.size());
+        assertEquals("9639bcbc-0089-4855-a793-44b940e52286", ids.get(0));
+        assertEquals("f034f71e-22a8-489b-8492-f5f7133559c1", ids.get(1));
+    }
+
+    @Test
+    public void testBuildLayeredAttributeJSON() {
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("displayName", "group1"));
+        attrs.add(AttributeBuilder.build("description", "This is\r\n\"group1\"."));
+
+        JSONObject jsonObject = groupProcessing.buildLayeredAttributeJSON(attrs);
+
+        assertEquals("group1", jsonObject.getString("displayName"));
+        assertEquals("This is\r\n\"group1\".", jsonObject.getString("description"));
+    }
+
+    @Test
+    public void testBuildLayeredAttribute() {
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("displayName", "group1"));
+        attrs.add(AttributeBuilder.build("description", "This is\r\n\"group1\"."));
+
+        List<JSONObject> jsonObjects = groupProcessing.buildLayeredAttribute(attrs, Collections.emptySet());
+
+        assertEquals(1, jsonObjects.size());
+        JSONObject jsonObject = jsonObjects.get(0);
+        assertEquals(2, jsonObject.length());
+        assertEquals("group1", jsonObject.getString("displayName"));
+        assertEquals("This is\r\n\"group1\".", jsonObject.getString("description"));
     }
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/MockGraphEndpoint.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/MockGraphEndpoint.java
@@ -1,0 +1,18 @@
+package com.evolveum.polygon.connector.msgraphapi;
+
+public class MockGraphEndpoint extends GraphEndpoint {
+
+    MockGraphEndpoint(MSGraphConfiguration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    protected void authenticate() {
+        // Do nothing
+    }
+
+    @Override
+    protected void initHttpClient() {
+        // Do nothing
+    }
+}

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/ObjectProcessingTest.java
@@ -2,8 +2,11 @@ package com.evolveum.polygon.connector.msgraphapi;
 
 import org.identityconnectors.framework.common.exceptions.ConfigurationException;
 import org.testng.Assert;
+import org.testng.AssertJUnit;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.*;
 
 /**
  * Unit test for {@link ObjectProcessing} utilities.
@@ -28,6 +31,6 @@ public class ObjectProcessingTest {
 
 	@Test
 	public void testSelector_valid() {
-		Assert.assertEquals("$select=foo,bar,baz", ObjectProcessing.selector("foo", "bar", "baz"));
+		assertEquals("$select=foo,bar,baz", ObjectProcessing.selector("foo", "bar", "baz"));
 	}
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/RoleProcessingTest.java
@@ -4,12 +4,13 @@ import com.evolveum.polygon.connector.msgraphapi.integration.BasicConfigurationF
 import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+
+import static org.testng.AssertJUnit.*;
 
 /**
  * Test case for {@link RoleProcessing}
@@ -23,15 +24,15 @@ public class RoleProcessingTest extends BasicConfigurationForTests {
         }
     }
 
-    final RoleProcessing roleProcessing = new RoleProcessing(new GraphEndpoint(getConfiguration()));
+    final RoleProcessing roleProcessing = new RoleProcessing(new MockGraphEndpoint(null));
 
     @Test
     public void testParseGroupMembers() throws Exception {
         final JSONObject membersJson = parseResource("groupMembers.json");
         final JSONArray jarr = roleProcessing.getJSONArray(membersJson.getJSONArray("value"), "id");
         final List<Object> ids = jarr.toList();
-        Assert.assertEquals(2, ids.size());
-        Assert.assertEquals("9639bcbc-0089-4855-a793-44b940e52286", ids.get(0));
-        Assert.assertEquals("f034f71e-22a8-489b-8492-f5f7133559c1", ids.get(1));
+        assertEquals(2, ids.size());
+        assertEquals("9639bcbc-0089-4855-a793-44b940e52286", ids.get(0));
+        assertEquals("f034f71e-22a8-489b-8492-f5f7133559c1", ids.get(1));
     }
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslatorFilterTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslatorFilterTest.java
@@ -2,10 +2,11 @@ package com.evolveum.polygon.connector.msgraphapi;
 
 import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.common.objects.OperationOptions;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
+
+import static org.testng.AssertJUnit.*;
 
 @Test(groups = "unit")
 public class SchemaTranslatorFilterTest {
@@ -16,8 +17,8 @@ public class SchemaTranslatorFilterTest {
         OperationOptions options = new OperationOptions(Collections.singletonMap(OperationOptions.OP_ATTRIBUTES_TO_GET, new String[]{"attr1"}));
         String[] attrs = schemaTranslator.filter(ObjectClass.ACCOUNT_NAME, options, "attr1", "attr2");
 
-        Assert.assertEquals(1, attrs.length);
-        Assert.assertEquals("attr1", attrs[0]);
+        assertEquals(1, attrs.length);
+        assertEquals("attr1", attrs[0]);
     }
 
     @Test
@@ -26,7 +27,7 @@ public class SchemaTranslatorFilterTest {
         String[] attrs = schemaTranslator.filter(ObjectClass.ACCOUNT_NAME, options, "attr");
 
         // no attributes are define in schema
-        Assert.assertEquals(0, attrs.length);
+        assertEquals(0, attrs.length);
     }
 
     @Test
@@ -34,7 +35,7 @@ public class SchemaTranslatorFilterTest {
         OperationOptions options = new OperationOptions(Collections.emptyMap());
         String[] attrs = schemaTranslator.filter(ObjectClass.ACCOUNT_NAME, options, "attr");
 
-        Assert.assertEquals(1, attrs.length);
-        Assert.assertEquals("attr", attrs[0]);
+        assertEquals(1, attrs.length);
+        assertEquals("attr", attrs[0]);
     }
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/UserProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/UserProcessingTest.java
@@ -1,10 +1,22 @@
 package com.evolveum.polygon.connector.msgraphapi;
 
 import com.evolveum.polygon.connector.msgraphapi.integration.BasicConfigurationForTests;
+import org.identityconnectors.common.security.GuardedString;
+import org.identityconnectors.framework.common.objects.Attribute;
+import org.identityconnectors.framework.common.objects.AttributeBuilder;
 import org.identityconnectors.framework.common.objects.OperationOptions;
 import org.identityconnectors.framework.common.objects.OperationOptionsBuilder;
-import org.testng.Assert;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.evolveum.polygon.connector.msgraphapi.UserProcessing.SPO_ATTRS;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Test case for {@link UserProcessing}
@@ -15,14 +27,140 @@ public class UserProcessingTest extends BasicConfigurationForTests {
     @Test
     public void testGetAttributesToGet() throws Exception {
         UserProcessing userProcessing = new UserProcessing(null, null);
-        Assert.assertNotNull(userProcessing.getAttributesToGet(null));
+        assertNotNull(userProcessing.getAttributesToGet(null));
 
         OperationOptions emptyOptions = new OperationOptionsBuilder().build();
-        Assert.assertNotNull(userProcessing.getAttributesToGet(emptyOptions));
+        assertNotNull(userProcessing.getAttributesToGet(emptyOptions));
 
         OperationOptions options = new OperationOptionsBuilder().setAttributesToGet("manager").build();
 
-        Assert.assertTrue(userProcessing.getAttributesToGet(options).contains("manager"));
-        Assert.assertFalse(userProcessing.getAttributesToGet(options).contains("signIn"));
+        assertTrue(userProcessing.getAttributesToGet(options).contains("manager"));
+        assertFalse(userProcessing.getAttributesToGet(options).contains("signIn"));
+    }
+
+    @Test
+    public void testBuildLayeredAttributeJSON() {
+        MockGraphEndpoint mockGraphEndpoint = new MockGraphEndpoint(null);
+        SchemaTranslator schemaTranslator = mockGraphEndpoint.getSchemaTranslator();
+        UserProcessing userProcessing = new UserProcessing(mockGraphEndpoint, schemaTranslator);
+
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("userPrincipalName", "foo@example.com"));
+        attrs.add(AttributeBuilder.build("mailNickname", "foo"));
+        attrs.add(AttributeBuilder.build("displayName", "Foo Bar"));
+        attrs.add(AttributeBuilder.build("mail", "foo@example.com"));
+        attrs.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
+        attrs.add(AttributeBuilder.build(ATTR_ICF_PASSWORD, new GuardedString("xWwvJ]6NMw+bWH-d".toCharArray())));
+        attrs.add(AttributeBuilder.build(ATTR_ICF_ENABLED, true));
+
+        JSONObject jsonObject = userProcessing.buildLayeredAttributeJSON(attrs);
+
+        assertEquals(6, jsonObject.length());
+        assertEquals("foo@example.com", jsonObject.getString("userPrincipalName"));
+        assertEquals("foo", jsonObject.getString("mailNickname"));
+        assertEquals("Foo Bar", jsonObject.getString("displayName"));
+        assertEquals("foo@example.com", jsonObject.getString("mail"));
+        assertTrue(jsonObject.getBoolean("accountEnabled"));
+        JSONObject passwordProfile = jsonObject.getJSONObject("passwordProfile");
+        assertNotNull(passwordProfile);
+        assertEquals(2, passwordProfile.length());
+        assertTrue(passwordProfile.getBoolean("forceChangePasswordNextSignIn"));
+        assertEquals("xWwvJ]6NMw+bWH-d", passwordProfile.getString("password"));
+    }
+
+    @Test
+    public void testBuildLayeredAttribute() {
+        MockGraphEndpoint mockGraphEndpoint = new MockGraphEndpoint(null);
+        SchemaTranslator schemaTranslator = mockGraphEndpoint.getSchemaTranslator();
+        UserProcessing userProcessing = new UserProcessing(mockGraphEndpoint, schemaTranslator);
+
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("businessPhones", "+1 425 555 0109"));
+        attrs.add(AttributeBuilder.build("officeLocation", "18/2111"));
+        attrs.add(AttributeBuilder.build("givenName", Collections.emptyList())); // Case of value removal
+        attrs.add(AttributeBuilder.build("onPremisesExtensionAttributes.extensionAttribute1", "ext1"));
+        attrs.add(AttributeBuilder.build("onPremisesExtensionAttributes.extensionAttribute15", "ext15"));
+        attrs.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
+        attrs.add(AttributeBuilder.build(ATTR_ICF_PASSWORD, new GuardedString("xWwvJ]6NMw+bWH-d".toCharArray())));
+        attrs.add(AttributeBuilder.build(ATTR_ICF_ENABLED, false));
+
+        List<JSONObject> jsonObjects = userProcessing.buildLayeredAttribute(attrs, SPO_ATTRS);
+
+        assertEquals(1, jsonObjects.size());
+        JSONObject jsonObject = jsonObjects.get(0);
+        assertEquals(6, jsonObject.length());
+        JSONArray businessPhones = jsonObject.getJSONArray("businessPhones");
+        assertEquals(1, businessPhones.length());
+        assertEquals("+1 425 555 0109", businessPhones.getString(0));
+        assertTrue(jsonObject.isNull("givenName"));
+        assertEquals("18/2111", jsonObject.getString("officeLocation"));
+        JSONObject onPremisesExtensionAttributes = jsonObject.getJSONObject("onPremisesExtensionAttributes");
+        assertNotNull(onPremisesExtensionAttributes);
+        assertEquals("ext1", onPremisesExtensionAttributes.getString("extensionAttribute1"));
+        assertEquals("ext15", onPremisesExtensionAttributes.getString("extensionAttribute15"));
+        JSONObject passwordProfile = jsonObject.getJSONObject("passwordProfile");
+        assertNotNull(passwordProfile);
+        assertEquals(2, passwordProfile.length());
+        assertTrue(passwordProfile.getBoolean("forceChangePasswordNextSignIn"));
+        assertEquals("xWwvJ]6NMw+bWH-d", passwordProfile.getString("password"));
+        assertFalse(jsonObject.getBoolean("accountEnabled"));
+    }
+
+    @Test
+    public void testBuildLayeredAttributeWithSPO() {
+        MockGraphEndpoint mockGraphEndpoint = new MockGraphEndpoint(null);
+        SchemaTranslator schemaTranslator = mockGraphEndpoint.getSchemaTranslator();
+        UserProcessing userProcessing = new UserProcessing(mockGraphEndpoint, schemaTranslator);
+
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("businessPhones", "+1 425 555 0109"));
+        attrs.add(AttributeBuilder.build("officeLocation", "18/2111"));
+        attrs.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
+        // SPO
+        attrs.add(AttributeBuilder.build("aboutMe", "About me"));
+        attrs.add(AttributeBuilder.build("mySite", "https://example.com"));
+        attrs.add(AttributeBuilder.build("schools", "A", "B"));
+
+        List<JSONObject> jsonObjects = userProcessing.buildLayeredAttribute(attrs, SPO_ATTRS);
+
+        assertEquals(2, jsonObjects.size());
+        JSONObject jsonObject = jsonObjects.get(0);
+        assertEquals(3, jsonObject.length());
+        JSONArray businessPhones = jsonObject.getJSONArray("businessPhones");
+        assertEquals(1, businessPhones.length());
+        assertEquals("+1 425 555 0109", businessPhones.getString(0));
+        assertEquals("18/2111", jsonObject.getString("officeLocation"));
+        JSONObject passwordProfile = jsonObject.getJSONObject("passwordProfile");
+        assertNotNull(passwordProfile);
+        assertEquals(1, passwordProfile.length());
+        assertTrue(passwordProfile.getBoolean("forceChangePasswordNextSignIn"));
+
+        JSONObject spoJsonObject = jsonObjects.get(1);
+        assertEquals(3, spoJsonObject.length());
+        assertEquals("About me", spoJsonObject.getString("aboutMe"));
+        assertEquals("https://example.com", spoJsonObject.getString("mySite"));
+        JSONArray schools = spoJsonObject.getJSONArray("schools");
+        assertEquals(2, schools.length());
+        assertEquals("A", schools.getString(0));
+        assertEquals("B", schools.getString(1));
+    }
+
+    @Test
+    public void testBuildLayeredAttributeSPOOnly() {
+        MockGraphEndpoint mockGraphEndpoint = new MockGraphEndpoint(null);
+        SchemaTranslator schemaTranslator = mockGraphEndpoint.getSchemaTranslator();
+        UserProcessing userProcessing = new UserProcessing(mockGraphEndpoint, schemaTranslator);
+
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("aboutMe", "About me"));
+        attrs.add(AttributeBuilder.build("mySite", "https://example.com"));
+
+        List<JSONObject> jsonObjects = userProcessing.buildLayeredAttribute(attrs, SPO_ATTRS);
+
+        assertEquals(1, jsonObjects.size());
+        JSONObject spoJsonObject = jsonObjects.get(0);
+        assertEquals(2, spoJsonObject.length());
+        assertEquals("About me", spoJsonObject.getString("aboutMe"));
+        assertEquals("https://example.com", spoJsonObject.getString("mySite"));
     }
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/BasicConfigurationForTests.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/BasicConfigurationForTests.java
@@ -25,7 +25,7 @@ public class BasicConfigurationForTests implements ObjectConstants {
     protected Set<String> licenses, licenses2;
     protected String roleWhichExistsInTenantDisplayName;
 
-    protected static int _WAIT_INTERVAL = 3;
+    protected static int _WAIT_INTERVAL = 30000;
     protected static int _REPEAT_COUNT = 10;
     protected static long _REPEAT_INTERVAL = 10000;
 
@@ -124,7 +124,8 @@ public class BasicConfigurationForTests implements ObjectConstants {
             }
 
             if (!notFound) {
-
+                // Wait until the deletion is complete
+                Thread.sleep(_WAIT_INTERVAL);
                 return;
             }
             iterator++;

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/DeleteActionTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/DeleteActionTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 public class DeleteActionTest extends BasicConfigurationForTests {
 
     @Test(expectedExceptions = UnknownUidException.class, priority = 24)
-    public void deleteUserTest() throws InterruptedException {
+    public void deleteUserTest() throws Exception {
 
         MSGraphConfiguration conf = getConfiguration();
         msGraphConnector.init(conf);
@@ -41,7 +41,7 @@ public class DeleteActionTest extends BasicConfigurationForTests {
 
 
         Uid testUserUid = msGraphConnector.create(objectClassAccount, attributesAccount, options);
-        msGraphConnector.delete(objectClassAccount, testUserUid, options);
+        deleteWaitAndRetry(objectClassAccount, testUserUid, options);
 
 
         ArrayList<ConnectorObject> resultsAccount = new ArrayList<>();
@@ -49,8 +49,6 @@ public class DeleteActionTest extends BasicConfigurationForTests {
 
         AttributeFilter equalsFilter;
         equalsFilter = (EqualsFilter) FilterBuilder.equalTo(testUserUid);
-
-        TimeUnit.SECONDS.sleep(_WAIT_INTERVAL);
 
         msGraphConnector.executeQuery(objectClassAccount, equalsFilter, handlerAccount, options);
 
@@ -66,7 +64,7 @@ public class DeleteActionTest extends BasicConfigurationForTests {
     }
 
     @Test(expectedExceptions = UnknownUidException.class, priority = 25)
-    public void deleteGroupTest() throws InterruptedException {
+    public void deleteGroupTest() throws Exception {
 
         MSGraphConfiguration conf = getConfiguration();
         msGraphConnector.init(conf);
@@ -82,7 +80,7 @@ public class DeleteActionTest extends BasicConfigurationForTests {
 
 
         Uid testGroupUid = msGraphConnector.create(groupObject, groupAttributes, options);
-        msGraphConnector.delete(groupObject, testGroupUid, options);
+        deleteWaitAndRetry(groupObject, testGroupUid, options);
 
 
         ArrayList<ConnectorObject> resultsGroup = new ArrayList<>();
@@ -91,7 +89,6 @@ public class DeleteActionTest extends BasicConfigurationForTests {
         AttributeFilter equalsFilter;
         equalsFilter = (EqualsFilter) FilterBuilder.equalTo(testGroupUid);
 
-        TimeUnit.SECONDS.sleep(_WAIT_INTERVAL);
         msGraphConnector.executeQuery(groupObject, equalsFilter, handlergroup, options);
 
         resultsGroup = handlergroup.getResult();

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/ListAllTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/ListAllTest.java
@@ -37,6 +37,7 @@ public class ListAllTest extends BasicConfigurationForTests {
         ArrayList<ConnectorObject> resultsGroup = new ArrayList<>();
         TestSearchResultsHandler handlerGroup = new TestSearchResultsHandler();
 
+        Thread.sleep(_WAIT_INTERVAL);
 
         msGraphConnector.executeQuery(objectClassGroup, null, handlerGroup, options);
 

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/UserPerformanceTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/UserPerformanceTest.java
@@ -19,7 +19,7 @@ public class UserPerformanceTest extends BasicConfigurationForTests {
 
 
     @Test(priority = 15)
-    public void CreateGroupAnd500UsersTest() {
+    public void CreateGroupAnd30UsersTest() {
         MSGraphConnector msGraphConnector = new MSGraphConnector();
 
         MSGraphConfiguration conf = getConfiguration();
@@ -60,12 +60,12 @@ public class UserPerformanceTest extends BasicConfigurationForTests {
     }
 
     @Test(priority = 16)
-    public void Search100GroupsTest() {
+    public void Search30UsersTest() throws InterruptedException {
         MSGraphConnector msGraphConnector = new MSGraphConnector();
 
         MSGraphConfiguration conf = getConfiguration();
         msGraphConnector.init(conf);
-        ObjectClass objectClassAccout = ObjectClass.ACCOUNT;
+        ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
 
         Map<String, Object> operationOptions = new HashMap<>();
         operationOptions.put("ALLOW_PARTIAL_ATTRIBUTE_VALUES", true);
@@ -87,7 +87,9 @@ public class UserPerformanceTest extends BasicConfigurationForTests {
             }
         };
 
-        msGraphConnector.executeQuery(objectClassAccout, null, handlerGroup, options);
+        Thread.sleep(_WAIT_INTERVAL);
+
+        msGraphConnector.executeQuery(objectClassAccount, null, handlerGroup, options);
 
         msGraphConnector.dispose();
 
@@ -97,7 +99,7 @@ public class UserPerformanceTest extends BasicConfigurationForTests {
     }
 
     @Test(priority = 17)
-    public void Update500UsersTest() {
+    public void Update30UsersTest() {
         MSGraphConnector msGraphConnector = new MSGraphConnector();
 
         MSGraphConfiguration conf = getConfiguration();
@@ -121,7 +123,7 @@ public class UserPerformanceTest extends BasicConfigurationForTests {
     }
 
     @Test(priority = 18)
-    public void Delete500UserTest() {
+    public void Delete30UserTest() {
         MSGraphConnector msGraphConnector = new MSGraphConnector();
         MSGraphConfiguration conf = getConfiguration();
         ObjectClass objectClassGroup = ObjectClass.GROUP;


### PR DESCRIPTION
Hello,

I have made the following improvements:

- Support for value containing strings that need to be escaped, such as CRLF. It had implemented own assembly of JSON strings, but had omitted to take into account the escaping. Therefore, I fixed it to use the JSON library.
- During the build of the JSON string, optimize multiple value checking to use cached schema.
- The Graph API for update was being called for each JSON key, which was inefficient. Therefore, I optimized the JSON build for update by aggregating them into two, one for Azure AD and one for SharePoint Online attributes.

Also, added the following minor bug fix:

- Mandatory checks are not performed before API calling