### PR TITLE
Fix: Search license by equals filter returns all licenses

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -173,7 +173,7 @@ public class LicenseProcessing extends ObjectProcessing {
         ConnectorObjectBuilder builder = new ConnectorObjectBuilder();
         builder.setObjectClass(OBJECT_CLASS);
 
-        getUIDIfExists(json, ATTR_SKUID, builder);
+        getUIDIfExists(json, ATTR_ID, builder);
         getNAMEIfExists(json, ATTR_SKUPAATNUMBER, builder);
 
         getIfExists(json, ATTR_ID, String.class, builder);

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/LicenseProcessing.java
@@ -4,17 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.identityconnectors.framework.common.objects.Attribute;
-import org.identityconnectors.framework.common.objects.AttributeInfo;
-import org.identityconnectors.framework.common.objects.AttributeInfoBuilder;
-import org.identityconnectors.framework.common.objects.AttributeUtil;
-import org.identityconnectors.framework.common.objects.ConnectorObjectBuilder;
-import org.identityconnectors.framework.common.objects.ObjectClass;
-import org.identityconnectors.framework.common.objects.ObjectClassInfo;
-import org.identityconnectors.framework.common.objects.ObjectClassInfoBuilder;
-import org.identityconnectors.framework.common.objects.OperationOptions;
-import org.identityconnectors.framework.common.objects.ResultsHandler;
-import org.identityconnectors.framework.common.objects.SchemaBuilder;
+import org.identityconnectors.framework.common.objects.*;
 import org.identityconnectors.framework.common.objects.filter.EqualsFilter;
 import org.identityconnectors.framework.common.objects.filter.Filter;
 import org.json.JSONArray;
@@ -156,7 +146,7 @@ public class LicenseProcessing extends ObjectProcessing {
             final String attrName = attr.getName();
             LOG.info("query instanceof EqualsFilter");
 
-            if (attrName.equals(ATTR_ID)) {
+            if (attrName.equals(ATTR_ID) || attrName.equals(Uid.NAME)) {
                 String value = AttributeUtil.getAsStringValue(attr);
                 if (value == null)
                     invalidAttributeValue("Uid", query);


### PR DESCRIPTION
Hello,

We have made two fixes related to search license by equals filter:

- Search by UID was being ignored by  the connector and listing all licenses, because the equals filter uses __UID__ and  not "id" as attribute name, so we added  __UID__ in the verification too.

- Search licenses in "/subscribedSkus" endpoint  requires the type [GUID]_[GUID] to find an specific license, however the connector is using SkuID and it is returning a "Bad request" status from  server. So we changed in "handleJSONObject" the __UID__ value to use the license "id" instead of skuid.
