### PR TITLE
Add post-creation sync check with exponential retries for users and groups

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/MSGraphConfiguration.java
@@ -41,6 +41,10 @@ public class MSGraphConfiguration extends AbstractConfiguration
 
     private boolean treatNetIdAsAlreadyExists;
     private boolean validateWithFailoverTrust = true;
+
+    private Integer postCreateReadRetryBaseDelayMs = 500;
+    private Integer postCreateReadMaxRetryCount = 5;
+
     private GraphConfigurationHandler configHandler = new GraphConfigurationHandler();
 
     @ConfigurationProperty(order = 10, displayMessageKey = "ClientId.display", helpMessageKey = "ClientId.help", required = true)
@@ -220,6 +224,24 @@ public class MSGraphConfiguration extends AbstractConfiguration
 
     public void setTreatNetIdAsAlreadyExists(boolean treatNetIdAsAlreadyExists) { this.treatNetIdAsAlreadyExists = treatNetIdAsAlreadyExists; }
 
+    @ConfigurationProperty(order = 160, displayMessageKey = "PostCreateReadRetryBaseDelayMs.display", helpMessageKey = "PostCreateReadRetryBaseDelayMs.help")
+    public Integer getPostCreateReadRetryBaseDelayMs() {
+        return postCreateReadRetryBaseDelayMs;
+    }
+
+    public void setPostCreateReadRetryBaseDelayMs(Integer postCreateReadRetryBaseDelayMs) {
+        this.postCreateReadRetryBaseDelayMs = postCreateReadRetryBaseDelayMs;
+    }
+
+    @ConfigurationProperty(order = 170, displayMessageKey = "PostCreateReadMaxRetryCount.display", helpMessageKey = "PostCreateReadMaxRetryCount.help")
+    public Integer getPostCreateReadMaxRetryCount() {
+        return postCreateReadMaxRetryCount;
+    }
+
+    public void setPostCreateReadMaxRetryCount(Integer postCreateReadMaxRetryCount) {
+        this.postCreateReadMaxRetryCount = postCreateReadMaxRetryCount;
+    }
+
     @Override
     public void validate() {
         LOG.info("Processing trough configuration validation procedure.");
@@ -276,6 +298,16 @@ public class MSGraphConfiguration extends AbstractConfiguration
 
             throw new ConfigurationException("The specified number for the maximum throttling request retries has to be " +
                     "a non negative number!");
+        }
+
+        if (postCreateReadRetryBaseDelayMs < 0) {
+            throw new ConfigurationException("The specified number for the post create read retry base delay in ms has to be " +
+                    "greater than zero!");
+        }
+
+        if (postCreateReadMaxRetryCount < 0) {
+            throw new ConfigurationException("The specified number for the post create read max retry count has to be " +
+                    "greater than zero!");
         }
 
         LOG.info("Configuration valid");

--- a/src/main/resources/com/evolveum/polygon/connector/msgraphapi/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/msgraphapi/Messages.properties
@@ -40,4 +40,3 @@ PostCreateReadRetryBaseDelayMs.display=Post create read retry base delay (ms)
 PostCreateReadRetryBaseDelayMs.help=Specifies initial delay (in ms) used for exponentially increasing wait time when retrying reads of just-created objects. Default 500 ms.
 PostCreateReadMaxRetryCount.display=Post create read max retry count
 PostCreateReadMaxRetryCount.help=Maximum number of retries when reading a just-created object that may not yet be visible due to eventual consistency. Default 5.
-

--- a/src/main/resources/com/evolveum/polygon/connector/msgraphapi/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/msgraphapi/Messages.properties
@@ -36,3 +36,13 @@ PrivateKeyPath.display=PrivateKey Path
 PrivateKeyPath.help=Path to private key (.der or .pem format).
 TreatNetIdErrorAsAlreadyExists.display=Treat InvalidNetIdError As AlreadyExist
 TreatNetIdErrorAsAlreadyExists.help=If set to true connector will treat 'Property netId is invalid' as valid alreadyExists exception.
+GroupCreateMinRetrievals.display=Minimum Retrieval Attempts for Group Creation Verification
+GroupCreateMinRetrievals.help=Specifies the minimum number of successful retrieval attempts required to confirm the existence of a newly created group in Entra ID. This setting helps ensure that group creation is fully propagated before completing the operation, minimizing the risk of retrieval inconsistencies.
+GroupCreateMaxRetries.display=Create Group Max Retries
+GroupCreateMaxRetries.help=Specify how many times we should search for group after it's creation, this should reduce likelihood of duplicate create.
+
+PostCreateReadRetryBaseDelayMs.display=Post create read retry base delay (ms)
+PostCreateReadRetryBaseDelayMs.help=Specifies initial delay (in ms) used for exponentially increasing wait time when retrying reads of just-created objects. Default 500 ms.
+PostCreateReadMaxRetryCount.display=Post create read max retry count
+PostCreateReadMaxRetryCount.help=Maximum number of retries when reading a just-created object that may not yet be visible due to eventual consistency. Default 5.
+

--- a/src/main/resources/com/evolveum/polygon/connector/msgraphapi/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/msgraphapi/Messages.properties
@@ -36,11 +36,6 @@ PrivateKeyPath.display=PrivateKey Path
 PrivateKeyPath.help=Path to private key (.der or .pem format).
 TreatNetIdErrorAsAlreadyExists.display=Treat InvalidNetIdError As AlreadyExist
 TreatNetIdErrorAsAlreadyExists.help=If set to true connector will treat 'Property netId is invalid' as valid alreadyExists exception.
-GroupCreateMinRetrievals.display=Minimum Retrieval Attempts for Group Creation Verification
-GroupCreateMinRetrievals.help=Specifies the minimum number of successful retrieval attempts required to confirm the existence of a newly created group in Entra ID. This setting helps ensure that group creation is fully propagated before completing the operation, minimizing the risk of retrieval inconsistencies.
-GroupCreateMaxRetries.display=Create Group Max Retries
-GroupCreateMaxRetries.help=Specify how many times we should search for group after it's creation, this should reduce likelihood of duplicate create.
-
 PostCreateReadRetryBaseDelayMs.display=Post create read retry base delay (ms)
 PostCreateReadRetryBaseDelayMs.help=Specifies initial delay (in ms) used for exponentially increasing wait time when retrying reads of just-created objects. Default 500 ms.
 PostCreateReadMaxRetryCount.display=Post create read max retry count


### PR DESCRIPTION
### Added two new connector configuration items:
- postCreateReadRetryBaseDelayMs
- postCreateReadMaxRetryCount
### Implemented repeated queries with exponentially increasing delay in the following situations:
- After user creation, querying their role membership
- After group creation, querying its existence by displayName

### Behavior without the above-mentioned fix:

MidPoint always tries to immediately fetch the object right after its creation, which is a problem with Entra ID, as synchronization of users and groups can take several seconds. For users, without the above-mentioned modification, this results in a cycle of AlreadyExists and UnknownUid exceptions, and for groups, it leads to the creation of multiple groups with the same name.
