### PR TITLE
Fix Microsoft Graph filter rendering for Boolean and null values, improves guest invitation creation logic, updates the Maven build for Java 17 and the current connector parent, fix the TestNG/Surefire setup so unit and integration tests run reliably.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This are permissions which you need to add to your Entra ID (former Azure Active
 * GroupMember.ReadWrite.All
 * PrivilegedAccess.Read.AzureADGroup
 * PrivilegedAccess.ReadWrite.AzureADGroup
+* User.Invite.All
 * User.Read.All
 * User.ReadWrite.All
 #### Optional: Role Membership Management

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>connector-parent</artifactId>
         <groupId>com.evolveum.polygon</groupId>
-        <version>1.5.1.3</version>
+        <version>1.5.2.0</version>
         <relativePath></relativePath>
     </parent>
 
@@ -35,9 +35,11 @@
     <name>connector-microsoft-graph-api</name>
 
     <properties>
+        <groups>unit</groups>
         <connectorPackage>com.evolveum.polygon</connectorPackage>
         <connectorClass>MSGraphConnectorConnector</connectorClass>
         <!--  <slf4jVersion>1.6.1</slf4jVersion>-->
+        <surefire.version>3.2.5</surefire.version>
     </properties>
 
     <repositories>
@@ -59,8 +61,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -75,12 +76,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <groups>unit</groups>
+                    <groups>${groups}</groups>
                     <excludes>
                         <exclude>**/UserPerformanceTest.java</exclude>
                         <exclude>**/GroupPerformanceTests.java</exclude>
                     </excludes>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${surefire.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>
@@ -98,23 +106,23 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20231013</version>
+            <version>20250517</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.6.4</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.15</version> <!-- non-vulnerable -->
+            <version>1.18.0</version> <!-- non-vulnerable -->
         </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14.0</version>
+            <version>2.18.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -134,12 +142,12 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.4.10</version>
+                <version>2.5.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.10.1</version>
+                <version>2.13.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -149,7 +157,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>2.2</version>
+                <version>2.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/UserProcessing.java
@@ -143,6 +143,7 @@ public class UserProcessing extends ObjectProcessing {
     private static final String ATTR_INVITE_DISPNAME = "invitedUserDisplayName";
     private static final String ATTR_INVITE_SEND_MESSAGE = "sendInvitationMessage";
     private static final String ATTR_INVITE_MSG_INFO = "invitedUserMessageInfo";
+    private static final String ATTR_CUSTOMIZED_MESSAGE_BODY = "customizedMessageBody";
     private static final String ATTR_INVITED_USER_TYPE = "invitedUserType";
 
     // GUEST ACCOUNT STATUS
@@ -916,6 +917,7 @@ public class UserProcessing extends ObjectProcessing {
         String upn = null;
         String displayName = null;
         String userType = null;
+        boolean hasPassword = false;
         Attribute managerId = null;
         Attribute assignedLicenses = null;
         Attribute photo = null;
@@ -942,14 +944,27 @@ public class UserProcessing extends ObjectProcessing {
                 case ATTR_USERPHOTO:
                     photo = attribute;
                     break;
+                case ATTR_ICF_PASSWORD:
+                    hasPassword = true;
+                    break;
             }
         }
 
-        final boolean hasUPN = upn != null;
-        final boolean invite = mail != null &&
-                !mail.split("@")[1].equals(getConfiguration().getTenantId()) &&
-                getConfiguration().isInviteGuests() &&
-                !hasUPN;
+        final boolean invite = getConfiguration().isInviteGuests() && StringUtils.isNotBlank(mail) && "Guest".equalsIgnoreCase(userType);
+
+        if (invite && StringUtils.isNotBlank(upn)) {
+            throw new InvalidAttributeValueException(
+                    "userPrincipalName must not be provided when creating guest by invitation. " +
+                            "Map mail and userType=Guest only."
+            );
+        }
+
+        if (invite && hasPassword) {
+            throw new InvalidAttributeValueException(
+                    "Password must not be provided when creating guest by invitation. " +
+                            "Guest authentication is handled by Microsoft Entra invitation redemption."
+            );
+        }
 
         final Uid newUid;
         if (invite) {
@@ -1212,7 +1227,7 @@ public class UserProcessing extends ObjectProcessing {
     }
 
 
-    private JSONObject buildInvitation(String displayName, String mail, String userType) {
+    /*private JSONObject buildInvitation(String displayName, String mail, String userType) {
         final JSONObject invitation = new JSONObject()
                 .put(ATTR_INVITE_SEND_MESSAGE, getConfiguration().isSendInviteMail())
                 .put(ATTR_INVITE_MSG_INFO, getConfiguration().getInviteMessage())
@@ -1221,6 +1236,48 @@ public class UserProcessing extends ObjectProcessing {
         if (displayName != null) invitation.put(ATTR_INVITE_DISPNAME, displayName);
         if (mail != null) invitation.put(ATTR_INVITED_USER_EMAIL, mail);
         if (userType != null) invitation.put(ATTR_INVITED_USER_TYPE, userType);
+
+        return invitation;
+    }*/
+    private JSONObject buildInvitation(
+            String displayName,
+            String mail,
+            String userType) {
+
+        final JSONObject invitation = new JSONObject()
+                .put(
+                        ATTR_INVITE_SEND_MESSAGE,
+                        getConfiguration().isSendInviteMail())
+                .put(
+                        ATTR_INVITE_REDIRECT,
+                        getConfiguration().getInviteRedirectUrl());
+
+        if (StringUtils.isNotBlank(displayName)) {
+            invitation.put(ATTR_INVITE_DISPNAME, displayName);
+        }
+
+        if (StringUtils.isNotBlank(mail)) {
+            invitation.put(ATTR_INVITED_USER_EMAIL, mail);
+        }
+
+        invitation.put(
+                ATTR_INVITED_USER_TYPE,
+                StringUtils.defaultIfBlank(userType, "Guest"));
+
+        String inviteMessage = getConfiguration().getInviteMessage();
+
+        if (getConfiguration().isSendInviteMail()
+                && StringUtils.isNotBlank(inviteMessage)) {
+
+            JSONObject messageInfo = new JSONObject()
+                    .put(
+                            ATTR_CUSTOMIZED_MESSAGE_BODY,
+                            inviteMessage);
+
+            invitation.put(
+                    ATTR_INVITE_MSG_INFO,
+                    messageInfo);
+        }
 
         return invitation;
     }

--- a/src/main/java/com/evolveum/polygon/connector/msgraphapi/util/FilterHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/msgraphapi/util/FilterHandler.java
@@ -115,54 +115,54 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
             CategorizedFilter categorizedFilter = snippets.get(snipp);
             Boolean isSearch = categorizedFilter.getIsSearch();
             Filter filter = categorizedFilter.getFilter();
-                         if (filter instanceof CompositeFilter || filter instanceof ContainsAllValuesFilter) {
+            if (filter instanceof CompositeFilter || filter instanceof ContainsAllValuesFilter) {
 
-                         } else if ( filter instanceof NotFilter && snipp.isEmpty()){
+            } else if ( filter instanceof NotFilter && snipp.isEmpty()){
 
-                         } else {
+            } else {
 
-                             if(filter instanceof NotFilter){
-                                 isSearch = checkIfFilterOrChildHasSearch(categorizedFilter.getFilter());
-                             }
+                if(filter instanceof NotFilter){
+                    isSearch = checkIfFilterOrChildHasSearch(categorizedFilter.getFilter());
+                }
 
-                             if (isSearch) {
+                if (isSearch) {
 
-                                 String previousSearchSnippet = p.getSearchExpression();
-                                 if(previousSearchSnippet!=null && !previousSearchSnippet.isEmpty()){
+                    String previousSearchSnippet = p.getSearchExpression();
+                    if(previousSearchSnippet!=null && !previousSearchSnippet.isEmpty()){
 
-                                     StringBuilder sb = new StringBuilder();
-                                     sb.append(wrapValue(snipp, _L_PAR, _R_PAR));
-                                     sb.append(_PADDING);
-                                     sb.append(AND_S_OP);
-                                     sb.append(_PADDING);
-                                     sb.append(wrapValue(previousSearchSnippet, _L_PAR, _R_PAR));
+                        StringBuilder sb = new StringBuilder();
+                        sb.append(wrapValue(snipp, _L_PAR, _R_PAR));
+                        sb.append(_PADDING);
+                        sb.append(AND_S_OP);
+                        sb.append(_PADDING);
+                        sb.append(wrapValue(previousSearchSnippet, _L_PAR, _R_PAR));
 
-                                     p.setSearchExpression(sb.toString());
-                                 } else {
+                        p.setSearchExpression(sb.toString());
+                    } else {
 
-                                     p.setSearchExpression(snipp);
-                                 }
+                        p.setSearchExpression(snipp);
+                    }
 
-                             } else {
+                } else {
 
-                                 String previousFilterSnippet = p.getFilterExpression();
-                                 if(previousFilterSnippet!=null && !previousFilterSnippet.isEmpty()){
+                    String previousFilterSnippet = p.getFilterExpression();
+                    if(previousFilterSnippet!=null && !previousFilterSnippet.isEmpty()){
 
-                                     StringBuilder sb = new StringBuilder();
-                                     sb.append(wrapValue(snipp, _L_PAR, _R_PAR));
-                                     sb.append(_PADDING);
-                                     sb.append(AND_OP);
-                                     sb.append(_PADDING);
-                                     sb.append(wrapValue(previousFilterSnippet, _L_PAR, _R_PAR));
+                        StringBuilder sb = new StringBuilder();
+                        sb.append(wrapValue(snipp, _L_PAR, _R_PAR));
+                        sb.append(_PADDING);
+                        sb.append(AND_OP);
+                        sb.append(_PADDING);
+                        sb.append(wrapValue(previousFilterSnippet, _L_PAR, _R_PAR));
 
-                                     p.setFilterExpression(sb.toString());
+                        p.setFilterExpression(sb.toString());
 
-                                 } else {
+                    } else {
 
-                                     p.setFilterExpression(snipp);
-                                 }
-                             }
-                         }
+                        p.setFilterExpression(snipp);
+                    }
+                }
+            }
         }
 
         if (wasFirst) {
@@ -258,9 +258,9 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
         LOG.ok("Generated query snippet: {0}", snippet);
 
-           p.setIdOrMembershipExpression(snippet);
-           p.setUseCount(true);
-            return p;
+        p.setIdOrMembershipExpression(snippet);
+        p.setUseCount(true);
+        return p;
 
     }
 
@@ -275,6 +275,11 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
         }
 
         Attribute attr = equalsFilter.getAttribute();
+
+        if (isNullFilterValue(attr)) {
+            // Microsoft Graph null equality requires advanced query parameters for directory objects.
+            p.setUseCount(true);
+        }
 
         String snippet = processStringFilter(attr, EQUALS_OP, p);
 
@@ -295,7 +300,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
     @Override
     public ResourceQuery visitExtendedFilter(ResourceQuery p, Filter filter) {
 
-       throw new ConnectorException("Filter 'EXTENDED FILTER' not implemented by the connector");
+        throw new ConnectorException("Filter 'EXTENDED FILTER' not implemented by the connector");
     }
 
     @Override
@@ -484,7 +489,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
             LOG.warn("Invalid filter state, potentially malformed query snippet: {0}", query);
         }
 
-          if (wasFirst) {
+        if (wasFirst) {
 
             p.setFilterExpression(query.toString());
 
@@ -511,13 +516,13 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
         Boolean isSearch = checkIfFilterOrChildHasSearch(orFilter);
 
-       if(checkIfFilterOrChildHasOtherThanSearch(orFilter) && isSearch){
+        if(checkIfFilterOrChildHasOtherThanSearch(orFilter) && isSearch){
 
 
-           new ConnectorException("Invalid filter combination, conjunction of other filters with contains queries " +
-                   "supported only with contains filter as a left or right side of the first 'AND' filter clause. " +
-                   "Please see documentation");
-       }
+            new ConnectorException("Invalid filter combination, conjunction of other filters with contains queries " +
+                    "supported only with contains filter as a left or right side of the first 'AND' filter clause. " +
+                    "Please see documentation");
+        }
 
         Boolean wasFirst = !afterFirtsOperation;
 
@@ -552,43 +557,43 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
                     isSearch = checkIfFilterOrChildHasSearch(filter.getFilter());
                 }
 
-                    if (isSearch) {
-                        String previousSearchSnippet = p.getSearchExpression();
+                if (isSearch) {
+                    String previousSearchSnippet = p.getSearchExpression();
 
-                        if(previousSearchSnippet!=null && !previousSearchSnippet.isEmpty()){
+                    if(previousSearchSnippet!=null && !previousSearchSnippet.isEmpty()){
 
 
-                            StringBuilder sb = new StringBuilder();
+                        StringBuilder sb = new StringBuilder();
 
-                            sb.append(wrapValue(snipp, _L_PAR, _R_PAR));
-                            sb.append(_PADDING);
-                            sb.append(OR_S_OP);
-                            sb.append(_PADDING);
-                            sb.append(wrapValue(previousSearchSnippet, _L_PAR, _R_PAR));
+                        sb.append(wrapValue(snipp, _L_PAR, _R_PAR));
+                        sb.append(_PADDING);
+                        sb.append(OR_S_OP);
+                        sb.append(_PADDING);
+                        sb.append(wrapValue(previousSearchSnippet, _L_PAR, _R_PAR));
 
-                            p.setSearchExpression(sb.toString());
-                        } else {
-                            p.setSearchExpression(snipp);
-                        }
+                        p.setSearchExpression(sb.toString());
+                    } else {
+                        p.setSearchExpression(snipp);
+                    }
 
+                } else {
+
+                    String previousFilterSnippet = p.getFilterExpression();
+                    if(previousFilterSnippet!=null && !previousFilterSnippet.isEmpty()) {
+
+                        StringBuilder sb = new StringBuilder();
+                        sb.append(wrapValue(snipp, _L_PAR, _R_PAR));
+                        sb.append(_PADDING);
+                        sb.append(OR_OP);
+                        sb.append(_PADDING);
+                        sb.append(wrapValue(previousFilterSnippet, _L_PAR, _R_PAR));
+
+                        p.setFilterExpression(sb.toString());
                     } else {
 
-                        String previousFilterSnippet = p.getFilterExpression();
-                        if(previousFilterSnippet!=null && !previousFilterSnippet.isEmpty()) {
-
-                            StringBuilder sb = new StringBuilder();
-                            sb.append(wrapValue(snipp, _L_PAR, _R_PAR));
-                            sb.append(_PADDING);
-                            sb.append(OR_OP);
-                            sb.append(_PADDING);
-                            sb.append(wrapValue(previousFilterSnippet, _L_PAR, _R_PAR));
-
-                            p.setFilterExpression(sb.toString());
-                        } else {
-
-                            p.setFilterExpression(snipp);
-                        }
+                        p.setFilterExpression(snipp);
                     }
+                }
             }
         }
 
@@ -703,7 +708,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
         List<String> nonWrapped = CollectionUtil.newList(GREATER_OR_EQUALS_OP, GREATER_OP, LESS_OP, LESS_OR_EQ_OP);
 
         if (attr != null) {
-            String singleValue = null;
+            Object singleValue = null;
             String name = attr.getName();
             List value = attr.getValue();
 
@@ -719,7 +724,7 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             if (value != null && !value.isEmpty()) {
 
-                singleValue = AttributeUtil.getSingleValue(attr).toString();
+                singleValue = AttributeUtil.getSingleValue(attr);
 
             } else {
 
@@ -731,14 +736,101 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
             query.append(_PADDING);
             if (!nonWrapped.contains(operator)) {
 
-                query.append(wrapValue(singleValue));
+                query.append(renderODataLiteral(name, singleValue));
             } else {
 
-                query.append(singleValue);
+                query.append(renderNonWrappedLiteral(singleValue));
             }
         }
 
         return query.toString();
+    }
+
+    private String renderNonWrappedLiteral(Object value) {
+        if (value == null) {
+            return "null";
+        }
+
+        return value.toString();
+    }
+
+    private String renderODataLiteral(String attributeName, Object value) {
+        if (value == null) {
+            return "null";
+        }
+
+        if (value instanceof Boolean) {
+            return value.toString().toLowerCase(Locale.ROOT);
+        }
+
+        if (value instanceof Number) {
+            return value.toString();
+        }
+
+        String stringValue = value.toString();
+
+        if (isBooleanAttribute(attributeName) && isBooleanLiteral(stringValue)) {
+            return stringValue.toLowerCase(Locale.ROOT);
+        }
+
+        if (isNullLiteralAttribute(attributeName) && isNullLiteral(stringValue)) {
+            return "null";
+        }
+
+        return wrapValue(stringValue);
+    }
+
+    private boolean isNullFilterValue(Attribute attr) {
+        if (attr == null) {
+            return false;
+        }
+
+        List value = attr.getValue();
+        if (value == null || value.isEmpty()) {
+            return true;
+        }
+
+        Object singleValue = AttributeUtil.getSingleValue(attr);
+        if (singleValue == null) {
+            return true;
+        }
+
+        return isNullLiteralAttribute(attr.getName()) && isNullLiteral(singleValue.toString());
+    }
+
+    private boolean isBooleanLiteral(String value) {
+        return "true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value);
+    }
+
+    private boolean isNullLiteral(String value) {
+        return "null".equalsIgnoreCase(value);
+    }
+
+    private boolean isBooleanAttribute(String attributeName) {
+        if (attributeName == null) {
+            return false;
+        }
+
+        return "accountEnabled".equals(attributeName)
+                || "onPremisesSyncEnabled".equals(attributeName)
+                || "mailEnabled".equals(attributeName)
+                || "securityEnabled".equals(attributeName)
+                || "isAssignableToRole".equals(attributeName);
+    }
+
+    private boolean isNullLiteralAttribute(String attributeName) {
+        if (attributeName == null) {
+            return false;
+        }
+
+        return "onPremisesSyncEnabled".equals(attributeName)
+                || "onPremisesImmutableId".equals(attributeName)
+                || "onPremisesLastSyncDateTime".equals(attributeName)
+                || "employeeHireDate".equals(attributeName)
+                || "employeeLeaveDateTime".equals(attributeName)
+                || "manager".equals(attributeName)
+                || "mobilePhone".equals(attributeName)
+                || "officeLocation".equals(attributeName);
     }
 
     private String processStringFunction(Attribute attr, String operator, ResourceQuery resourceQuery) {
@@ -762,7 +854,10 @@ public class FilterHandler implements FilterVisitor<ResourceQuery, ResourceQuery
 
             if (value != null && !value.isEmpty()) {
 
-                singleValue = AttributeUtil.getSingleValue(attr).toString();
+                Object valueObject = AttributeUtil.getSingleValue(attr);
+                if (valueObject != null) {
+                    singleValue = valueObject.toString();
+                }
 
             } else {
 

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/MockGraphEndpoint.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/MockGraphEndpoint.java
@@ -3,7 +3,13 @@ package com.evolveum.polygon.connector.msgraphapi;
 public class MockGraphEndpoint extends GraphEndpoint {
 
     MockGraphEndpoint(MSGraphConfiguration configuration) {
-        super(configuration);
+        super(configuration != null ? configuration : defaultConfiguration());
+    }
+
+    private static MSGraphConfiguration defaultConfiguration() {
+        MSGraphConfiguration configuration = new MSGraphConfiguration();
+        configuration.setDiscoverSchema(false);
+        return configuration;
     }
 
     @Override

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslatorFilterTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/SchemaTranslatorFilterTest.java
@@ -10,7 +10,7 @@ import static org.testng.AssertJUnit.*;
 
 @Test(groups = "unit")
 public class SchemaTranslatorFilterTest {
-    SchemaTranslator schemaTranslator = new SchemaTranslator(null);
+    SchemaTranslator schemaTranslator = new MockGraphEndpoint(null).getSchemaTranslator();
 
     @Test
     void testFilterWithAttrToGetOperationOptions() {

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/UserProcessingTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/UserProcessingTest.java
@@ -2,12 +2,15 @@ package com.evolveum.polygon.connector.msgraphapi;
 
 import com.evolveum.polygon.connector.msgraphapi.integration.BasicConfigurationForTests;
 import org.identityconnectors.common.security.GuardedString;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
 import org.identityconnectors.framework.common.objects.Attribute;
 import org.identityconnectors.framework.common.objects.AttributeBuilder;
 import org.identityconnectors.framework.common.objects.AttributeDelta;
 import org.identityconnectors.framework.common.objects.AttributeDeltaBuilder;
 import org.identityconnectors.framework.common.objects.OperationOptions;
 import org.identityconnectors.framework.common.objects.OperationOptionsBuilder;
+import org.identityconnectors.framework.common.objects.Uid;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.annotations.Test;
@@ -26,6 +29,22 @@ import static org.testng.AssertJUnit.*;
  */
 @Test(groups = "unit")
 public class UserProcessingTest extends BasicConfigurationForTests {
+
+    private static class RecordingGraphEndpoint extends MockGraphEndpoint {
+        private JSONObject lastPayload;
+        private String lastPath;
+
+        RecordingGraphEndpoint(MSGraphConfiguration configuration) {
+            super(configuration);
+        }
+
+        @Override
+        public JSONObject callRequest(HttpEntityEnclosingRequestBase request, JSONObject json, Boolean parseResult) {
+            this.lastPath = request.getURI().getPath();
+            this.lastPayload = json;
+            return new JSONObject().put("invitedUser", new JSONObject().put("id", "invited-user-id"));
+        }
+    }
 
     @Test
     public void testGetAttributesToGet() throws Exception {
@@ -226,5 +245,177 @@ public class UserProcessingTest extends BasicConfigurationForTests {
         assertEquals(2, interests.length());
         assertEquals("a", interests.getString(0));
         assertEquals("b", interests.getString(1));
+    }
+
+    @Test
+    public void testCreateGuestUsesInvitationWhenUpnAndPasswordAreMissing() {
+        MSGraphConfiguration configuration = new MSGraphConfiguration();
+        configuration.setTenantId("example.com");
+        configuration.setInviteGuests(true);
+        configuration.setSendInviteMail(true);
+        configuration.setInviteRedirectUrl("https://myapps.microsoft.com");
+
+        RecordingGraphEndpoint endpoint = new RecordingGraphEndpoint(configuration);
+        UserProcessing userProcessing = new UserProcessing(endpoint, endpoint.getSchemaTranslator());
+
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("mail", "external@example.com"));
+        attrs.add(AttributeBuilder.build("displayName", "External Guest"));
+        attrs.add(AttributeBuilder.build("userType", "Guest"));
+
+        Uid uid = userProcessing.createUser(attrs);
+
+        assertEquals("invited-user-id", uid.getUidValue());
+        assertEquals("/v1.0/invitations", endpoint.lastPath);
+        assertNotNull(endpoint.lastPayload);
+        assertEquals("external@example.com", endpoint.lastPayload.getString("invitedUserEmailAddress"));
+        assertEquals("External Guest", endpoint.lastPayload.getString("invitedUserDisplayName"));
+        assertEquals("Guest", endpoint.lastPayload.getString("invitedUserType"));
+        assertTrue(endpoint.lastPayload.getBoolean("sendInvitationMessage"));
+        assertEquals("https://myapps.microsoft.com", endpoint.lastPayload.getString("inviteRedirectUrl"));
+        assertFalse(endpoint.lastPayload.has("invitedUserMessageInfo"));
+    }
+
+    @Test(expectedExceptions = InvalidAttributeValueException.class,
+            expectedExceptionsMessageRegExp = ".*userPrincipalName must not be provided.*")
+    public void testCreateGuestInvitationRejectsUserPrincipalName() {
+        MSGraphConfiguration configuration = new MSGraphConfiguration();
+        configuration.setTenantId("example.com");
+        configuration.setInviteGuests(true);
+        configuration.setInviteRedirectUrl("https://myapps.microsoft.com");
+
+        RecordingGraphEndpoint endpoint = new RecordingGraphEndpoint(configuration);
+        UserProcessing userProcessing = new UserProcessing(endpoint, endpoint.getSchemaTranslator());
+
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("mail", "external@example.com"));
+        attrs.add(AttributeBuilder.build("displayName", "External Guest"));
+        attrs.add(AttributeBuilder.build("userType", "Guest"));
+        attrs.add(AttributeBuilder.build("userPrincipalName", "external_example.com#EXT#@tenant.onmicrosoft.com"));
+
+        userProcessing.createUser(attrs);
+    }
+
+    @Test
+    public void testCreateGuestInvitationWrapsCustomMessage() {
+        MSGraphConfiguration configuration = invitationConfiguration();
+        configuration.setSendInviteMail(true);
+        configuration.setInviteMessage("Welcome to the organization.");
+
+        RecordingGraphEndpoint endpoint =
+                new RecordingGraphEndpoint(configuration);
+
+        UserProcessing userProcessing =
+                new UserProcessing(
+                        endpoint,
+                        endpoint.getSchemaTranslator());
+
+        userProcessing.createUser(guestAttributes());
+
+        JSONObject payload = endpoint.lastPayload;
+
+        assertNotNull(payload);
+        assertTrue(payload.has("invitedUserMessageInfo"));
+
+        Object messageInfoValue =
+                payload.get("invitedUserMessageInfo");
+
+        assertTrue(
+                "invitedUserMessageInfo must be a JSON object",
+                messageInfoValue instanceof JSONObject);
+
+        JSONObject messageInfo =
+                (JSONObject) messageInfoValue;
+
+        assertEquals(
+                "Welcome to the organization.",
+                messageInfo.getString(
+                        "customizedMessageBody"));
+
+        assertTrue(
+                payload.getBoolean(
+                        "sendInvitationMessage"));
+    }
+
+    @Test
+    public void testCreateGuestInvitationOmitsEmptyMessageInfo() {
+        MSGraphConfiguration configuration = invitationConfiguration();
+        configuration.setSendInviteMail(true);
+        configuration.setInviteMessage("");
+
+        RecordingGraphEndpoint endpoint =
+                new RecordingGraphEndpoint(configuration);
+
+        UserProcessing userProcessing =
+                new UserProcessing(
+                        endpoint,
+                        endpoint.getSchemaTranslator());
+
+        userProcessing.createUser(guestAttributes());
+
+        JSONObject payload = endpoint.lastPayload;
+
+        assertNotNull(payload);
+
+        assertFalse(
+                payload.has(
+                        "invitedUserMessageInfo"));
+
+        assertTrue(
+                payload.getBoolean(
+                        "sendInvitationMessage"));
+    }
+
+    @Test(expectedExceptions = InvalidAttributeValueException.class,
+            expectedExceptionsMessageRegExp = ".*Password must not be provided.*")
+    public void testCreateGuestInvitationRejectsPassword() {
+        MSGraphConfiguration configuration = new MSGraphConfiguration();
+        configuration.setTenantId("example.com");
+        configuration.setInviteGuests(true);
+        configuration.setInviteRedirectUrl("https://myapps.microsoft.com");
+
+        RecordingGraphEndpoint endpoint = new RecordingGraphEndpoint(configuration);
+        UserProcessing userProcessing = new UserProcessing(endpoint, endpoint.getSchemaTranslator());
+
+        Set<Attribute> attrs = new HashSet<>();
+        attrs.add(AttributeBuilder.build("mail", "external@example.com"));
+        attrs.add(AttributeBuilder.build("displayName", "External Guest"));
+        attrs.add(AttributeBuilder.build("userType", "Guest"));
+        attrs.add(AttributeBuilder.build(ATTR_ICF_PASSWORD, new GuardedString("DoNotUseThisPassword1".toCharArray())));
+
+        userProcessing.createUser(attrs);
+    }
+
+    private MSGraphConfiguration invitationConfiguration() {
+        MSGraphConfiguration configuration =
+                new MSGraphConfiguration();
+
+        configuration.setTenantId("example.com");
+        configuration.setInviteGuests(true);
+        configuration.setInviteRedirectUrl(
+                "https://myapplications.microsoft.com");
+
+        return configuration;
+    }
+
+    private Set<Attribute> guestAttributes() {
+        Set<Attribute> attributes = new HashSet<>();
+
+        attributes.add(
+                AttributeBuilder.build(
+                        "mail",
+                        "external@example.com"));
+
+        attributes.add(
+                AttributeBuilder.build(
+                        "displayName",
+                        "External Guest"));
+
+        attributes.add(
+                AttributeBuilder.build(
+                        "userType",
+                        "Guest"));
+
+        return attributes;
     }
 }

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/FilteringTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/FilteringTest.java
@@ -2020,6 +2020,164 @@ public class FilteringTest extends BasicConfigurationForTests {
         deleteWaitAndRetry(objectClassGroup, groupYellow, goptions);
     }
 
+    @Test(priority = 43, groups = "integration")
+    public void filteringAccountEqualsBooleanValues() throws Exception {
+
+        msGraphConfiguration = getConfiguration();
+        msGraphConnector.init(msGraphConfiguration);
+
+        OperationOptions options = getDefaultAccountOperationOptions();
+        ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
+
+        String enabledLocalPart = "filter-bool-enabled-" + System.currentTimeMillis();
+        String disabledLocalPart = "filter-bool-disabled-" + System.currentTimeMillis();
+
+        Uid enabledUser = null;
+        Uid disabledUser = null;
+
+        try {
+            enabledUser = createFilteringAccount(enabledLocalPart, true, options);
+            disabledUser = createFilteringAccount(disabledLocalPart, false, options);
+
+            AttributeFilter enabledFilter = (EqualsFilter) FilterBuilder.equalTo(
+                    AttributeBuilder.build("accountEnabled", true));
+            AttributeFilter enabledNameFilter = (StartsWithFilter) FilterBuilder.startsWith(
+                    AttributeBuilder.build(Name.NAME, enabledLocalPart));
+            AndFilter enabledAndFilter = (AndFilter) FilterBuilder.and(enabledFilter, enabledNameFilter);
+
+            assertFilterReturnsUid(
+                    objectClassAccount,
+                    enabledAndFilter,
+                    options,
+                    enabledUser,
+                    "Boolean filter accountEnabled=true did not return created user"
+            );
+
+            AttributeFilter disabledFilter = (EqualsFilter) FilterBuilder.equalTo(
+                    AttributeBuilder.build("accountEnabled", false));
+            AttributeFilter disabledNameFilter = (StartsWithFilter) FilterBuilder.startsWith(
+                    AttributeBuilder.build(Name.NAME, disabledLocalPart));
+            AndFilter disabledAndFilter = (AndFilter) FilterBuilder.and(disabledFilter, disabledNameFilter);
+
+            assertFilterReturnsUid(
+                    objectClassAccount,
+                    disabledAndFilter,
+                    options,
+                    disabledUser,
+                    "Boolean filter accountEnabled=false did not return created user"
+            );
+
+        } finally {
+            deleteIfCreated(objectClassAccount, enabledUser, options);
+            deleteIfCreated(objectClassAccount, disabledUser, options);
+        }
+    }
+
+    @Test(priority = 44, groups = "integration")
+    public void filteringAccountEqualsNullValues() throws Exception {
+
+        msGraphConfiguration = getConfiguration();
+        msGraphConnector.init(msGraphConfiguration);
+
+        OperationOptions options = getDefaultAccountOperationOptions();
+        ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
+
+        String localPart = "filter-null-sync-" + System.currentTimeMillis();
+
+        Uid user = null;
+
+        try {
+            user = createFilteringAccount(localPart, true, options);
+
+            AttributeFilter nullFilter = (EqualsFilter) FilterBuilder.equalTo(
+                    AttributeBuilder.build("onPremisesSyncEnabled"));
+            AttributeFilter nameFilter = (StartsWithFilter) FilterBuilder.startsWith(
+                    AttributeBuilder.build(Name.NAME, localPart));
+            AndFilter nullAndNameFilter = (AndFilter) FilterBuilder.and(nullFilter, nameFilter);
+
+            assertFilterReturnsUid(
+                    objectClassAccount,
+                    nullAndNameFilter,
+                    options,
+                    user,
+                    "Null filter onPremisesSyncEnabled=null did not return created cloud-only user"
+            );
+
+            AttributeFilter nullStringFilter = (EqualsFilter) FilterBuilder.equalTo(
+                    AttributeBuilder.build("onPremisesSyncEnabled", "null"));
+            AndFilter nullStringAndNameFilter = (AndFilter) FilterBuilder.and(nullStringFilter, nameFilter);
+
+            assertFilterReturnsUid(
+                    objectClassAccount,
+                    nullStringAndNameFilter,
+                    options,
+                    user,
+                    "String null filter onPremisesSyncEnabled='null' did not return created cloud-only user"
+            );
+
+        } finally {
+            deleteIfCreated(objectClassAccount, user, options);
+        }
+    }
+
+    private Uid createFilteringAccount(String localPart, boolean enabled, OperationOptions options) throws Exception {
+        ObjectClass objectClassAccount = ObjectClass.ACCOUNT;
+        String upn = localPart + "@" + domain;
+
+        Set<Attribute> attributesAccount = new HashSet<>();
+        attributesAccount.add(AttributeBuilder.build("accountEnabled", enabled));
+        attributesAccount.add(AttributeBuilder.build("passwordProfile.forceChangePasswordNextSignIn", true));
+        attributesAccount.add(AttributeBuilder.build("displayName", localPart));
+        attributesAccount.add(AttributeBuilder.build("mail", upn));
+        attributesAccount.add(AttributeBuilder.build("mailNickname", localPart));
+        attributesAccount.add(AttributeBuilder.build("userPrincipalName", upn));
+        attributesAccount.add(AttributeBuilder.build("__PASSWORD__",
+                new GuardedString("HelloPassword99".toCharArray())));
+
+        try {
+            return msGraphConnector.create(objectClassAccount, attributesAccount, options);
+        } catch (InvalidAttributeValueException e) {
+            if (e.getLocalizedMessage().contains("Property netId is invalid")) {
+                LOG.warn("False 'netId is invalid error' again, ignoring. Executing search to retrieve UID.");
+                return fetchUidAtFalseValidationException(upn);
+            }
+            throw e;
+        }
+    }
+
+    private void assertFilterReturnsUid(ObjectClass objectClass, Filter filter, OperationOptions options,
+                                        Uid expectedUid, String failMessage) throws InterruptedException {
+
+        for (int i = 0; i < _REPEAT_COUNT; i++) {
+            TestSearchResultsHandler handler = getResultHandler();
+
+            msGraphConnector.executeQuery(objectClass, filter, handler, options);
+
+            if (containsUid(handler.getResult(), expectedUid)) {
+                return;
+            }
+
+            Thread.sleep(_REPEAT_INTERVAL);
+        }
+
+        Assert.fail(failMessage + ": " + expectedUid);
+    }
+
+    private boolean containsUid(List<ConnectorObject> results, Uid expectedUid) {
+        for (ConnectorObject object : results) {
+            if (expectedUid.equals(object.getUid())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void deleteIfCreated(ObjectClass objectClass, Uid uid, OperationOptions options) throws Exception {
+        if (uid != null) {
+            deleteWaitAndRetry(objectClass, uid, options);
+        }
+    }
+
    private Uid fetchUidAtFalseValidationException(String upn) throws InterruptedException {
 
 

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/ListAllTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/integration/ListAllTest.java
@@ -4,7 +4,7 @@ import com.evolveum.polygon.connector.msgraphapi.MSGraphConnector;
 import static com.evolveum.polygon.connector.msgraphapi.RoleProcessing.ROLE_NAME;
 import com.evolveum.polygon.connector.msgraphapi.common.TestSearchResultsHandler;
 import org.identityconnectors.framework.common.objects.*;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.*;

--- a/src/test/java/com/evolveum/polygon/connector/msgraphapi/util/FilterHandlerTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/msgraphapi/util/FilterHandlerTest.java
@@ -1,0 +1,67 @@
+package com.evolveum.polygon.connector.msgraphapi.util;
+
+import org.identityconnectors.framework.common.objects.AttributeBuilder;
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.filter.Filter;
+import org.identityconnectors.framework.common.objects.filter.FilterBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "unit")
+public class FilterHandlerTest {
+
+    private ResourceQuery translate(Filter filter) {
+        return filter.accept(
+                new FilterHandler(),
+                new ResourceQuery(ObjectClass.ACCOUNT, "id", "userPrincipalName"));
+    }
+
+    @Test
+    public void testBooleanFalseIsRenderedAsODataLiteral() {
+        ResourceQuery query = translate(FilterBuilder.equalTo(
+                AttributeBuilder.build("onPremisesSyncEnabled", false)));
+
+        assertEquals("$filter=onPremisesSyncEnabled eq false", query.toString());
+    }
+
+    @Test
+    public void testBooleanTrueIsRenderedAsODataLiteral() {
+        ResourceQuery query = translate(FilterBuilder.equalTo(
+                AttributeBuilder.build("accountEnabled", true)));
+
+        assertEquals("$filter=accountEnabled eq true", query.toString());
+    }
+
+    @Test
+    public void testBooleanStringOnBooleanAttributeIsRenderedAsODataLiteral() {
+        ResourceQuery query = translate(FilterBuilder.equalTo(
+                AttributeBuilder.build("onPremisesSyncEnabled", "false")));
+
+        assertEquals("$filter=onPremisesSyncEnabled eq false", query.toString());
+    }
+
+    @Test
+    public void testEmptyValueIsRenderedAsNullLiteral() {
+        ResourceQuery query = translate(FilterBuilder.equalTo(
+                AttributeBuilder.build("onPremisesSyncEnabled")));
+
+        assertEquals("$filter=onPremisesSyncEnabled eq null&$count=true", query.toString());
+    }
+
+    @Test
+    public void testNullStringOnNullableAttributeIsRenderedAsNullLiteral() {
+        ResourceQuery query = translate(FilterBuilder.equalTo(
+                AttributeBuilder.build("onPremisesSyncEnabled", "null")));
+
+        assertEquals("$filter=onPremisesSyncEnabled eq null&$count=true", query.toString());
+    }
+
+    @Test
+    public void testRegularStringStillQuotedAndEscaped() {
+        ResourceQuery query = translate(FilterBuilder.equalTo(
+                AttributeBuilder.build("surname", "O'Connor")));
+
+        assertEquals("$filter=surname eq 'O''Connor'", query.toString());
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes Microsoft Graph filter rendering for Boolean and null values, improves guest invitation creation logic, updates the Maven build for Java 17 and the current connector parent, and fixes the TestNG/Surefire setup so unit and integration tests run reliably.

### Filter

The connector now renders OData Boolean and null literals instead of wrapping them as strings.

Examples:

- `accountEnabled = true` -> `accountEnabled eq true`
- `onPremisesSyncEnabled = false` -> `onPremisesSyncEnabled eq false`
- `onPremisesSyncEnabled = null` -> `onPremisesSyncEnabled eq null`

Null equality also enables `$count=true`, which is required for Microsoft Graph advanced directory queries.

### Guest invitation

Guest invitation creation is now selected explicitly by:

- `inviteGuests = true`
- `mail` is present
- `userType = Guest`

The connector no longer relies on comparing the mail domain with `tenantId`.

The invitation path now rejects invalid guest-create input:

- `userPrincipalName` must not be provided for invitation-based guest creation.
- Password must not be provided for invitation-based guest creation.

This avoids accidentally creating a normal user or sending invalid invitation payloads.

### Invitation message payload

`UserProcessing.buildInvitation()` now creates `invitedUserMessageInfo` according to the Microsoft Graph schema.

Previously, the configured invitation message was sent directly as a string:

```json
{
  "invitedUserMessageInfo": "Welcome message"
}
```
Microsoft Graph requires invitedUserMessageInfo to be an object. The connector now sends:

```json
{
    "invitedUserMessageInfo": {
      "customizedMessageBody": "Welcome message"
    }
}
```

The invitedUserMessageInfo property is omitted when the configured invitation message is empty or blank. This allows Microsoft Graph to use its default invitation message.

The invitation payload continues to include:

invitedUserEmailAddress
invitedUserDisplayName when available
invitedUserType
inviteRedirectUrl
sendInvitationMessage

Reference: Microsoft Graph invitedUserMessageInfo resource documentation:
https://learn.microsoft.com/en-us/graph/api/resources/invitedusermessageinfo?view=graph-rest-1.0

### Test infrastructure

This PR also fixes and improves tests:

- Uses Java 17 compiler release configuration.
- Uses TestNG Surefire provider explicitly.
- Keeps `unit` as the default test group.
- Fixes `MockGraphEndpoint` initialization so unit tests do not fail on null configuration.
- Fixes `SchemaTranslatorFilterTest` to use a mock endpoint-backed schema translator.
- Replaces the remaining JUnit Assert import in `ListAllTest` with TestNG Assert.

### Added test coverage

Unit tests:

- Boolean filter literal rendering
- Null filter literal rendering
- String escaping in filters
- Guest invitation positive path
- Guest invitation validation for forbidden UPN
- Guest invitation validation for forbidden password
- Guest invitation custom message wrapped in invitedUserMessageInfo.customizedMessageBody
- Empty invitation message omits invitedUserMessageInfo

Integration tests:

- Search by `accountEnabled = true`
- Search by `accountEnabled = false`
- Search by `onPremisesSyncEnabled = null`
- Search by string `"null"` mapped to OData null literal

## Notes

Integration tests require a real Microsoft Entra test tenant and valid application credentials in local test properties. They create and delete test users, so they should not be run against a production tenant.

## Testing

Unit tests:

```bash
mvn clean install
```

Integration tests:

```bash
mvn  -Dtest=FilteringTest -Dgroups=integration test
```

Targeted invitation unit tests:

```bash
mvn -Dtest=UserProcessingTest#testCreateGuestUsesInvitationWhenUpnAndPasswordAreMissing+testCreateGuestInvitationRejectsUserPrincipalName+testCreateGuestInvitationRejectsPassword -Dgroups=unit test
```

### Build and dependency updates

This PR also updates the Maven build configuration to align the connector with the current connector parent and Java baseline.

POM changes include:

- Updates `connector-parent` to `1.5.2.0`.
- Sets the compiler configuration to Java 17 using:

```xml
    <release>17</release>
```
Keeps unit as the default TestNG group via:

```xml
    <groups>unit</groups>
```
Adds an explicit Surefire version property:

```xml
    <surefire.version>3.2.5</surefire.version>
```
Forces Maven Surefire to use the TestNG provider by adding surefire-testng as a plugin dependency.
This prevents Surefire from auto-detecting the JUnit Platform provider and silently running zero TestNG tests.

Dependency updates include:

- org.json:json updated to 20250517.
- commons-codec:commons-codec updated to 1.18.0.
- commons-io:commons-io updated to 2.18.0 for test scope.
- org.slf4j:slf4j-simple updated to 1.7.36.

Dependency management updates include:

- org.bouncycastle:bcprov-jdk15on pinned to 1.70.
- com.nimbusds:nimbus-jose-jwt pinned to 10.0.2.
- net.minidev:json-smart pinned to 2.5.2.
- com.google.code.gson:gson pinned to 2.13.1.
- org.apache.commons:commons-lang3 pinned to 3.18.0.
- org.yaml:snakeyaml pinned to 2.4.